### PR TITLE
[SELC-2363] - Configurazione variabile d'ambiente per Service type

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # see https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
-* @pagopa/selfcare-contributors @antonioT90 @KevinSi96 @SalvatorManna @manuraf
+* @pagopa/selfcare-contributors @antonioT90 @KevinSi96 @SalvatorManna @manuraf @gianmarcoplutino @andrea-putzu

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImpl.java
@@ -106,7 +106,7 @@ class InstitutionServiceImpl implements InstitutionService {
         userInfoFilter.setProductRoles(productRoles);
         userInfoFilter.setAllowedState(Optional.of(EnumSet.of(RelationshipState.ACTIVE)));
         Collection<UserInfo> result = partyConnector.getUsers(userInfoFilter);
-        if (serviceType.contains(xSelfCareUid)) {
+        if (xSelfCareUid != null && serviceType.contains(xSelfCareUid)) {
             result.forEach(userInfo ->
                     userInfo.setUser(userRegistryConnector.getUserByInternalId(userInfo.getId(), USER_FIELD_LIST_FISCAL_CODE)));
         } else {

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImpl.java
@@ -19,6 +19,7 @@ import it.pagopa.selfcare.external_api.model.user.User;
 import it.pagopa.selfcare.external_api.model.user.UserInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -45,16 +46,18 @@ class InstitutionServiceImpl implements InstitutionService {
     private final MsCoreConnector msCoreConnector;
     private final UserRegistryConnector userRegistryConnector;
 
-    private final static String serviceType = "onboarding-interceptor";
+    private final Set<String> serviceType;
 
     @Autowired
     InstitutionServiceImpl(PartyConnector partyConnector,
                            ProductsConnector productsConnector,
-                           MsCoreConnector msCoreConnector, UserRegistryConnector userRegistryConnector) {
+                           MsCoreConnector msCoreConnector, UserRegistryConnector userRegistryConnector,
+                           @Value("${external_api.allowed-service-types}")String[] serviceType) {
         this.partyConnector = partyConnector;
         this.productsConnector = productsConnector;
         this.msCoreConnector = msCoreConnector;
         this.userRegistryConnector = userRegistryConnector;
+        this.serviceType = Set.of(serviceType);
     }
 
     @Override
@@ -103,7 +106,7 @@ class InstitutionServiceImpl implements InstitutionService {
         userInfoFilter.setProductRoles(productRoles);
         userInfoFilter.setAllowedState(Optional.of(EnumSet.of(RelationshipState.ACTIVE)));
         Collection<UserInfo> result = partyConnector.getUsers(userInfoFilter);
-        if (serviceType.equals(xSelfCareUid)) {
+        if (serviceType.contains(xSelfCareUid)) {
             result.forEach(userInfo ->
                     userInfo.setUser(userRegistryConnector.getUserByInternalId(userInfo.getId(), USER_FIELD_LIST_FISCAL_CODE)));
         } else {

--- a/core/src/main/resources/config/core-config.properties
+++ b/core/src/main/resources/config/core-config.properties
@@ -1,1 +1,2 @@
 external_api.institutions-allowed-list=${ONBOARDING_ALLOWED_INSTITUTIONS_PRODUCTS:null}
+external_api.allowed-service-types=${ALLOWED_SERVICE_TYPES:onboarding-interceptor,external-interceptor}

--- a/core/src/test/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImplTest.java
@@ -7,6 +7,7 @@ import it.pagopa.selfcare.external_api.api.MsCoreConnector;
 import it.pagopa.selfcare.external_api.api.PartyConnector;
 import it.pagopa.selfcare.external_api.api.ProductsConnector;
 import it.pagopa.selfcare.external_api.api.UserRegistryConnector;
+import it.pagopa.selfcare.external_api.core.config.CoreTestConfig;
 import it.pagopa.selfcare.external_api.exceptions.ResourceNotFoundException;
 import it.pagopa.selfcare.external_api.model.institutions.GeographicTaxonomy;
 import it.pagopa.selfcare.external_api.model.institutions.Institution;
@@ -24,11 +25,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.test.context.TestSecurityContextHolder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.*;
 
@@ -39,21 +42,28 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        InstitutionServiceImpl.class,
+        CoreTestConfig.class
+})
+@TestPropertySource(properties = {
+        "ALLOWED_SERVICE_TYPES=external-interceptor,onboarding-interceptor"
+})
 class InstitutionServiceImplTest {
-    @InjectMocks
+    @Autowired
     private InstitutionServiceImpl institutionService;
 
-    @Mock
+    @MockBean
     private PartyConnector partyConnectorMock;
 
-    @Mock
+    @MockBean
     private ProductsConnector productsConnectorMock;
 
-    @Mock
+    @MockBean
     private UserRegistryConnector userRegistryConnectorMock;
 
-    @Mock
+    @MockBean
     private MsCoreConnector msCoreConnectorMock;
 
     @BeforeEach

--- a/core/src/test/java/it/pagopa/selfcare/external_api/core/config/CoreTestConfig.java
+++ b/core/src/test/java/it/pagopa/selfcare/external_api/core/config/CoreTestConfig.java
@@ -1,0 +1,9 @@
+package it.pagopa.selfcare.external_api.core.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+@TestConfiguration
+@Import(CoreConfig.class)
+public class CoreTestConfig {
+}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -85,3 +85,4 @@ affinity: {}
 
 config:
   APPLICATIONINSIGHTS_ROLE_NAME: "external-api"
+  ALLOWED_SERVICE_TYPES: "onboarding-interceptor","external-interceptor"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -85,4 +85,4 @@ affinity: {}
 
 config:
   APPLICATIONINSIGHTS_ROLE_NAME: "external-api"
-  ALLOWED_SERVICE_TYPES: "onboarding-interceptor","external-interceptor"
+  ALLOWED_SERVICE_TYPES: onboarding-interceptor,external-interceptor


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Removed hard coded service type from InstitutionServiceImpl 

#### Motivation and Context

Needed to make serviceType configurable in order to retrieve Users FiscalCodes based on caller Id (X-selfcare-uid)

#### How Has This Been Tested?

The microservice has been deployed on dev environment and the api has been tested for different service types


#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.