### PR TITLE
fix: remove duplicated connection timeout

### DIFF
--- a/connector/rest/src/main/resources/config/party-process-rest-client.properties
+++ b/connector/rest/src/main/resources/config/party-process-rest-client.properties
@@ -9,7 +9,6 @@ rest-client.party-process.createInstitutionUsingExternalId.path=/institutions/{e
 rest-client.party-process.onboardingOrganization.path=/onboarding/institution/complete
 rest-client.party-process.createInstitutionRaw.path=/institutions/insert/{externalId}
 rest-client.party-process.getUserInstitutionRelationshipsByExternalId.path=/external/institutions/{externalId}/relationships
-feign.client.config.party-process.connectTimeout=${USERVICE_PARTY_PROCESS_REST_CLIENT_CONNECT_TIMEOUT:${REST_CLIENT_CONNECT_TIMEOUT:5000}}
 feign.client.config.party-process.requestInterceptors[0]=it.pagopa.selfcare.commons.connector.rest.interceptor.AuthorizationHeaderInterceptor
 feign.client.config.party-process.requestInterceptors[1]=it.pagopa.selfcare.commons.connector.rest.interceptor.PartyTraceIdInterceptor
 feign.client.config.party-process.errorDecoder=it.pagopa.selfcare.external_api.connector.rest.decoder.FeignErrorDecoder


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

set REST_CLIENT_READ_TIMEOUT to 30 sec
set REST_CLIENT_CONNECT_TIMEOUT to 30 sec

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Onboarding request takes a long time, increasing timeout is a temporany solution before moving to async handling

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.