### PR TITLE
add empty collection for geographicTaxonomy SELC-3289

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/OnboardingDataMapper.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/OnboardingDataMapper.java
@@ -3,6 +3,8 @@ package it.pagopa.selfcare.external_api.model.onboarding;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Collections;
+
 @RequiredArgsConstructor(access = AccessLevel.NONE)
 public class OnboardingDataMapper {
 
@@ -32,6 +34,7 @@ public class OnboardingDataMapper {
         institutionUpdate.setAddress(pdaOnboardingData.getAddress());
         institutionUpdate.setTaxCode(pdaOnboardingData.getTaxCode());
         institutionUpdate.setZipCode(pdaOnboardingData.getZipCode());
+        institutionUpdate.setGeographicTaxonomies(Collections.emptyList());
         return institutionUpdate;
     }
 }


### PR DESCRIPTION
#### List of Changes

Added empty list of geographic taxonomies before calling completeOnboarding

#### Motivation and Context

geographic taxonomies list required to procede with onboarding

#### How Has This Been Tested?
Local environment

#### Screenshots (if appropriate):


#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.