### PR TITLE
SELC-3289 Added contractPath to /onboarding/pda API 

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/OnboardingDataMapper.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/OnboardingDataMapper.java
@@ -18,7 +18,8 @@ public class OnboardingDataMapper {
         onboardingData.setOrigin(pdaOnboardingData.getOrigin());
         onboardingData.setUsers(pdaOnboardingData.getUsers());
         onboardingData.setBilling(pdaOnboardingData.getBilling());
-
+        onboardingData.setContractVersion(pdaOnboardingData.getContractVersion());
+        onboardingData.setContractPath(pdaOnboardingData.getContractPath());
         InstitutionUpdate institutionUpdate = getInstitutionUpdate(pdaOnboardingData);
         onboardingData.setInstitutionUpdate(institutionUpdate);
 

--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/PdaOnboardingData.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/PdaOnboardingData.java
@@ -24,6 +24,9 @@ public class PdaOnboardingData {
     private String description;
     private Billing billing;
 
+    private String contractPath;
+    private String contractVersion;
+
     public List<User> getUsers() {
         return Optional.ofNullable(users).orElse(Collections.emptyList());
     }

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/OnboardingServiceImpl.java
@@ -319,6 +319,8 @@ class OnboardingServiceImpl implements OnboardingService {
         pdaOnboardingData.setInstitutionExternalId(institution.getExternalId());
         pdaOnboardingData.setInstitutionType(institution.getInstitutionType());
         pdaOnboardingData.setOrigin(institution.getOrigin());
+        pdaOnboardingData.setContractPath("import-from-pda");
+        pdaOnboardingData.setContractVersion("0.0");
         OnboardingData onboardingData = toOnboardingData(pdaOnboardingData);
 
         partyConnector.autoApprovalOnboarding(onboardingData);


### PR DESCRIPTION
#### List of Changes

Added contractPath in onboarding/pda API

#### Motivation and Context

contractPath and contractVersion are required fields to complete onboarding on ms-core API

#### How Has This Been Tested?

local environment

#### Screenshots (if appropriate):


#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.