### PR TITLE
[SELC-3214] feat: added userStatus into productInfo node for getUserInfo

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2007,6 +2007,9 @@
           },
           "role" : {
             "type" : "string"
+          },
+          "status" : {
+            "type" : "string"
           }
         }
       },

--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/ProductInfo.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/ProductInfo.java
@@ -11,4 +11,5 @@ public class ProductInfo {
     private String id;
     private String role;
     private OffsetDateTime createdAt;
+    private String status;
 }

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/UserServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/UserServiceImpl.java
@@ -45,7 +45,6 @@ public class UserServiceImpl implements UserService {
             throw new ResourceNotFoundException("User with fiscal code " + fiscalCode + " not found");
         }
 
-        //Add user uuid into claims
         User user = searchResult.get();
 
         OnboardingInfoResponse onboardingInfoResponse = msCoreConnector.getInstitutionProductsInfo(user.getId());


### PR DESCRIPTION
#### List of Changes

Added userStatus into productInfo node for getUserInfo API

#### Motivation and Context

This change was requested from support service in order to have info about status for onboarded product linked to an user

#### How Has This Been Tested?

I have run ms-core and external-api-backend microservices and tested the api getUserInfo