### PR TITLE
Fix: retrieve Institution description from ms-core before calling onboarding/complete API

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/OnboardingServiceImpl.java
@@ -2,7 +2,6 @@ package it.pagopa.selfcare.external_api.core;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
-import it.pagopa.selfcare.commons.base.utils.Origin;
 import it.pagopa.selfcare.external_api.api.MsPartyRegistryProxyConnector;
 import it.pagopa.selfcare.external_api.api.PartyConnector;
 import it.pagopa.selfcare.external_api.api.ProductsConnector;
@@ -37,7 +36,6 @@ import org.springframework.util.StringUtils;
 
 import javax.validation.ValidationException;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static it.pagopa.selfcare.commons.base.utils.Origin.*;
 import static it.pagopa.selfcare.commons.base.utils.ProductId.PROD_INTEROP;
@@ -328,6 +326,7 @@ class OnboardingServiceImpl implements OnboardingService {
         pdaOnboardingData.setInstitutionExternalId(institution.getExternalId());
         pdaOnboardingData.setInstitutionType(institution.getInstitutionType());
         pdaOnboardingData.setOrigin(institution.getOrigin());
+        pdaOnboardingData.setDescription(institution.getDescription());
         pdaOnboardingData.setContractPath("import-from-pda");
         pdaOnboardingData.setContractVersion("0.0");
         pdaOnboardingData.setSendCompleteOnboardingEmail(Boolean.FALSE);
@@ -549,7 +548,7 @@ class OnboardingServiceImpl implements OnboardingService {
     private Billing createBilling(Relationships relationships, InstitutionResource ipaInstitutionResource) {
         Billing billing = null;
         if (relationships.getItems() != null && !relationships.getItems().isEmpty()) {
-            List<Relationship> relationshipsWithBilling = relationships.getItems().stream().filter(relationship -> relationship.getBilling() != null).collect(Collectors.toList());
+            List<Relationship> relationshipsWithBilling = relationships.getItems().stream().filter(relationship -> relationship.getBilling() != null).toList();
             if (!relationshipsWithBilling.isEmpty()) {
                 billing = relationshipsWithBilling.get(0).getBilling();
             }


### PR DESCRIPTION
#### List of Changes

Added institution description to request body of onboarding/complete API

#### Motivation and Context

We need to get the description of the institution created with the api /institution/from-pda and set it in the request body of the call to onboarding/complete. Because the description we get from the from-pda call might be different than what we provided as input, if the institution is created from IPA.

#### How Has This Been Tested?


#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.