### PR TITLE
[SELC-3460] feat: added tag external-v2 for automatic generation of open-api

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -38,7 +38,7 @@
   "paths" : {
     "/institutions" : {
       "get" : {
-        "tags" : [ "institutions" ],
+        "tags" : [ "external-v2" ],
         "summary" : "getInstitutions",
         "description" : "The service retrieves all the onboarded institutions related to the logged user",
         "operationId" : "getInstitutionsUsingGET",
@@ -114,7 +114,7 @@
     },
     "/institutions/byGeoTaxonomies" : {
       "get" : {
-        "tags" : [ "institutions" ],
+        "tags" : [ "external-v2" ],
         "summary" : "getInstitutionsByGeoTaxonomies",
         "description" : "The service retrieves all the institutions based on given a list of geotax ids and a searchMode",
         "operationId" : "getInstitutionsByGeoTaxonomiesUsingGET",
@@ -201,7 +201,7 @@
     },
     "/institutions/{institutionId}/contract" : {
       "get" : {
-        "tags" : [ "institutions" ],
+        "tags" : [ "external-v2", "support" ],
         "summary" : "getContract",
         "description" : "Service to retrieve a contract given institutionId and productId",
         "operationId" : "getContractUsingGET",
@@ -284,7 +284,7 @@
     },
     "/institutions/{institutionId}/geographicTaxonomy" : {
       "get" : {
-        "tags" : [ "institutions" ],
+        "tags" : [ "external-v2" ],
         "summary" : "getInstitutionGeographicTaxonomies",
         "description" : "The service retrieve the institution's geographic taxonomy",
         "operationId" : "getInstitutionGeographicTaxonomiesUsingGET",
@@ -360,7 +360,7 @@
     },
     "/institutions/{institutionId}/products" : {
       "get" : {
-        "tags" : [ "institutions" ],
+        "tags" : [ "external-v2" ],
         "summary" : "getInstitutionUserProducts",
         "description" : "Service to retrieve all active products for given institution and logged user",
         "operationId" : "getInstitutionUserProductsUsingGET",
@@ -436,7 +436,7 @@
     },
     "/institutions/{institutionId}/products/{productId}/users" : {
       "get" : {
-        "tags" : [ "institutions" ],
+        "tags" : [ "external-v2" ],
         "summary" : "getInstitutionProductsUsers",
         "description" : "Service to get all the active users related to a specific pair of institution-product",
         "operationId" : "getInstitutionProductsUsersUsingGET",
@@ -1076,7 +1076,7 @@
     },
     "/users" : {
       "post" : {
-        "tags" : [ "support" ],
+        "tags" : [ "external-v2", "support" ],
         "summary" : "getUserInfo",
         "description" : "Service to retrieve user info including institutions and products linked to him",
         "operationId" : "getUserInfoUsingPOST",

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -38,7 +38,7 @@
   "paths" : {
     "/institutions" : {
       "get" : {
-        "tags" : [ "external-v2" ],
+        "tags" : [ "external-v2", "institutions" ],
         "summary" : "getInstitutions",
         "description" : "The service retrieves all the onboarded institutions related to the logged user",
         "operationId" : "getInstitutionsUsingGET",
@@ -114,7 +114,7 @@
     },
     "/institutions/byGeoTaxonomies" : {
       "get" : {
-        "tags" : [ "external-v2" ],
+        "tags" : [ "external-v2", "institutions" ],
         "summary" : "getInstitutionsByGeoTaxonomies",
         "description" : "The service retrieves all the institutions based on given a list of geotax ids and a searchMode",
         "operationId" : "getInstitutionsByGeoTaxonomiesUsingGET",
@@ -201,7 +201,7 @@
     },
     "/institutions/{institutionId}/contract" : {
       "get" : {
-        "tags" : [ "external-v2", "support" ],
+        "tags" : [ "external-v2", "institutions", "support" ],
         "summary" : "getContract",
         "description" : "Service to retrieve a contract given institutionId and productId",
         "operationId" : "getContractUsingGET",
@@ -284,7 +284,7 @@
     },
     "/institutions/{institutionId}/geographicTaxonomy" : {
       "get" : {
-        "tags" : [ "external-v2" ],
+        "tags" : [ "external-v2", "institutions" ],
         "summary" : "getInstitutionGeographicTaxonomies",
         "description" : "The service retrieve the institution's geographic taxonomy",
         "operationId" : "getInstitutionGeographicTaxonomiesUsingGET",
@@ -360,7 +360,7 @@
     },
     "/institutions/{institutionId}/products" : {
       "get" : {
-        "tags" : [ "external-v2" ],
+        "tags" : [ "external-v2", "institutions" ],
         "summary" : "getInstitutionUserProducts",
         "description" : "Service to retrieve all active products for given institution and logged user",
         "operationId" : "getInstitutionUserProductsUsingGET",
@@ -436,7 +436,7 @@
     },
     "/institutions/{institutionId}/products/{productId}/users" : {
       "get" : {
-        "tags" : [ "external-v2" ],
+        "tags" : [ "external-v2", "institutions" ],
         "summary" : "getInstitutionProductsUsers",
         "description" : "Service to get all the active users related to a specific pair of institution-product",
         "operationId" : "getInstitutionProductsUsersUsingGET",
@@ -1076,7 +1076,7 @@
     },
     "/users" : {
       "post" : {
-        "tags" : [ "external-v2", "support" ],
+        "tags" : [ "external-v2", "support", "users" ],
         "summary" : "getUserInfo",
         "description" : "Service to retrieve user info including institutions and products linked to him",
         "operationId" : "getUserInfoUsingPOST",

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1076,7 +1076,7 @@
     },
     "/users" : {
       "post" : {
-        "tags" : [ "users" ],
+        "tags" : [ "support" ],
         "summary" : "getUserInfo",
         "description" : "Service to retrieve user info including institutions and products linked to him",
         "operationId" : "getUserInfoUsingPOST",

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/InstitutionController.java
@@ -3,6 +3,8 @@ package it.pagopa.selfcare.external_api.web.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import it.pagopa.selfcare.external_api.core.ContractService;
 import it.pagopa.selfcare.external_api.core.InstitutionService;
 import it.pagopa.selfcare.external_api.model.documents.ResourceResponse;
@@ -54,6 +56,7 @@ public class InstitutionController {
         this.institutionResourceMapper = institutionResourceMapper;
     }
 
+    @Tag(name = "external-v2")
     @GetMapping(value = "")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external_api.institutions.api.getInstitutions}")
@@ -70,6 +73,7 @@ public class InstitutionController {
         return institutionResources;
     }
 
+    @Tag(name = "external-v2")
     @GetMapping(value = "/{institutionId}/products")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external_api.institutions.api.getInstitutionUserProducts}")
@@ -86,7 +90,7 @@ public class InstitutionController {
         return productResources;
     }
 
-
+    @Tag(name = "external-v2")
     @GetMapping(value = "/{institutionId}/products/{productId}/users")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external_api.institutions.api.getInstitutionProductUsers}")
@@ -113,6 +117,7 @@ public class InstitutionController {
         return result;
     }
 
+    @Tag(name = "external-v2")
     @GetMapping(value = "/{institutionId}/geographicTaxonomy")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external-api.institutions.api.getInstitutionGeographicTaxonomy}")
@@ -130,6 +135,7 @@ public class InstitutionController {
         return geographicTaxonomies;
     }
 
+    @Tag(name = "external-v2")
     @GetMapping(value = "/byGeoTaxonomies")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external-api.institutions.api.getInstitutionByGeoTaxonomies}")
@@ -146,6 +152,7 @@ public class InstitutionController {
         return result;
     }
 
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "support")})
     @GetMapping(value = "/{institutionId}/contract", produces = APPLICATION_OCTET_STREAM_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external_api.documents.api.getContract}")

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/InstitutionController.java
@@ -56,7 +56,7 @@ public class InstitutionController {
         this.institutionResourceMapper = institutionResourceMapper;
     }
 
-    @Tag(name = "external-v2")
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "institutions")})
     @GetMapping(value = "")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external_api.institutions.api.getInstitutions}")
@@ -73,7 +73,7 @@ public class InstitutionController {
         return institutionResources;
     }
 
-    @Tag(name = "external-v2")
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "institutions")})
     @GetMapping(value = "/{institutionId}/products")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external_api.institutions.api.getInstitutionUserProducts}")
@@ -90,7 +90,7 @@ public class InstitutionController {
         return productResources;
     }
 
-    @Tag(name = "external-v2")
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "institutions")})
     @GetMapping(value = "/{institutionId}/products/{productId}/users")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external_api.institutions.api.getInstitutionProductUsers}")
@@ -117,7 +117,7 @@ public class InstitutionController {
         return result;
     }
 
-    @Tag(name = "external-v2")
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "institutions")})
     @GetMapping(value = "/{institutionId}/geographicTaxonomy")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external-api.institutions.api.getInstitutionGeographicTaxonomy}")
@@ -135,7 +135,7 @@ public class InstitutionController {
         return geographicTaxonomies;
     }
 
-    @Tag(name = "external-v2")
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "institutions")})
     @GetMapping(value = "/byGeoTaxonomies")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external-api.institutions.api.getInstitutionByGeoTaxonomies}")
@@ -152,7 +152,7 @@ public class InstitutionController {
         return result;
     }
 
-    @Tags({@Tag(name = "external-v2"), @Tag(name = "support")})
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "support"), @Tag(name = "institutions")})
     @GetMapping(value = "/{institutionId}/contract", produces = APPLICATION_OCTET_STREAM_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external_api.documents.api.getContract}")

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/UserController.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import it.pagopa.selfcare.external_api.core.UserService;
 import it.pagopa.selfcare.external_api.model.user.UserInfoWrapper;
 import it.pagopa.selfcare.external_api.web.model.mapper.UserInfoResourceMapper;
@@ -34,7 +35,7 @@ public class UserController {
         this.userInfoResourceMapper = userInfoResourceMapper;
     }
 
-    @Tag(name = "support")
+    @Tags({@Tag(name = "support"), @Tag(name = "external-v2")})
     @PostMapping
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external_api.user.api.getUserInfo}")

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/UserController.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.external_api.web.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import it.pagopa.selfcare.external_api.core.UserService;
 import it.pagopa.selfcare.external_api.model.user.UserInfoWrapper;
 import it.pagopa.selfcare.external_api.web.model.mapper.UserInfoResourceMapper;
@@ -33,7 +34,8 @@ public class UserController {
         this.userInfoResourceMapper = userInfoResourceMapper;
     }
 
-    @PostMapping(value = "")
+    @Tag(name = "support")
+    @PostMapping
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external_api.user.api.getUserInfo}")
     public UserInfoResource getUserInfo(@ApiParam("${swagger.external_api.user.model.searchUser}")

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
         this.userInfoResourceMapper = userInfoResourceMapper;
     }
 
-    @Tags({@Tag(name = "support"), @Tag(name = "external-v2")})
+    @Tags({@Tag(name = "support"), @Tag(name = "external-v2"), @Tag(name = "users")})
     @PostMapping
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external_api.user.api.getUserInfo}")


### PR DESCRIPTION
#### List of Changes

Added new tag **external-v2** for operation that will be include into open-api for APIM

#### Motivation and Context

In order to avoid manual construction of open-api for APIM, all operations that will be included into this document are tagged with **external-v2** or **support**. In this way, a step of github action will scan them and automatically include into open-api.