### PR TITLE
[SELC - 3708] feat: added activatedAd in OnboardingImportContract

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/OnboardingImportContract.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/OnboardingImportContract.java
@@ -11,5 +11,6 @@ public class OnboardingImportContract {
     private String filePath;
     private String contractType;
     private OffsetDateTime createdAt;
+    private OffsetDateTime activatedAt;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/model/mapper/OnboardingMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/model/mapper/OnboardingMapper.java
@@ -1,11 +1,13 @@
 package it.pagopa.selfcare.external_api.web.model.mapper;
 
 
+import io.jsonwebtoken.lang.Assert;
 import it.pagopa.selfcare.external_api.model.onboarding.*;
 import it.pagopa.selfcare.external_api.web.model.onboarding.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.time.OffsetDateTime;
 import java.util.stream.Collectors;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -19,6 +21,12 @@ public class OnboardingMapper {
             resource.setFilePath(model.getFilePath());
             resource.setContractType(model.getContractType());
             resource.setCreatedAt(model.getOnboardingDate());
+            if( model.getOnboardingDate() != null) {
+                resource.setActivatedAt(model.getOnboardingDate());
+            }
+            else {
+                resource.setActivatedAt(OffsetDateTime.now());
+            }
         }
         return resource;
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- added new activadetAt information in OnboardingImportContract Object

#### Motivation and Context

This addition was necessary because the oldOnboardingContract and autoApproval APIs invoke the API present on the core microservice to complete onboarding

#### How Has This Been Tested?

the application was started locally, together with the core microservice and the APIs described above were subsequently invoked. We then verified that the activatedAt field was stored in the Token Entity

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.