### PR TITLE
[SELC-4032] ops: move /v1 from helm to controller

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -36,7 +36,7 @@
     "description" : "User Controller"
   } ],
   "paths" : {
-    "/institutions" : {
+    "/v1/institutions" : {
       "get" : {
         "tags" : [ "external-v2", "institutions" ],
         "summary" : "getInstitutions",
@@ -112,7 +112,7 @@
         } ]
       }
     },
-    "/institutions/byGeoTaxonomies" : {
+    "/v1/institutions/byGeoTaxonomies" : {
       "get" : {
         "tags" : [ "external-v2", "institutions" ],
         "summary" : "getInstitutionsByGeoTaxonomies",
@@ -199,7 +199,7 @@
         } ]
       }
     },
-    "/institutions/{institutionId}/contract" : {
+    "/v1/institutions/{institutionId}/contract" : {
       "get" : {
         "tags" : [ "external-v2", "institutions", "support" ],
         "summary" : "getContract",
@@ -282,7 +282,7 @@
         } ]
       }
     },
-    "/institutions/{institutionId}/geographicTaxonomy" : {
+    "/v1/institutions/{institutionId}/geographicTaxonomy" : {
       "get" : {
         "tags" : [ "external-v2", "institutions" ],
         "summary" : "getInstitutionGeographicTaxonomies",
@@ -358,7 +358,7 @@
         } ]
       }
     },
-    "/institutions/{institutionId}/products" : {
+    "/v1/institutions/{institutionId}/products" : {
       "get" : {
         "tags" : [ "external-v2", "institutions" ],
         "summary" : "getInstitutionUserProducts",
@@ -434,7 +434,7 @@
         } ]
       }
     },
-    "/institutions/{institutionId}/products/{productId}/users" : {
+    "/v1/institutions/{institutionId}/products/{productId}/users" : {
       "get" : {
         "tags" : [ "external-v2", "institutions" ],
         "summary" : "getInstitutionProductsUsers",
@@ -546,7 +546,7 @@
         } ]
       }
     },
-    "/onboarding" : {
+    "/v1/onboarding" : {
       "post" : {
         "tags" : [ "onboarding" ],
         "summary" : "onboarding",
@@ -611,7 +611,7 @@
         } ]
       }
     },
-    "/onboarding/pda/{injectionInstitutionType}" : {
+    "/v1/onboarding/pda/{injectionInstitutionType}" : {
       "post" : {
         "tags" : [ "onboarding" ],
         "summary" : "autoApprovalOnboardingFromPda",
@@ -676,7 +676,7 @@
         } ]
       }
     },
-    "/onboarding/{externalInstitutionId}" : {
+    "/v1/onboarding/{externalInstitutionId}" : {
       "post" : {
         "tags" : [ "onboarding" ],
         "summary" : "oldContractOnboarding",
@@ -761,7 +761,7 @@
         } ]
       }
     },
-    "/onboarding/{externalInstitutionId}/products/{productId}" : {
+    "/v1/onboarding/{externalInstitutionId}/products/{productId}" : {
       "post" : {
         "tags" : [ "onboarding" ],
         "summary" : "autoApprovalOnboarding",
@@ -856,7 +856,7 @@
         } ]
       }
     },
-    "/pn-pg/institutions/add" : {
+    "/v1/pn-pg/institutions/add" : {
       "post" : {
         "tags" : [ "institutions-pnpg" ],
         "summary" : "addInstitution",
@@ -918,7 +918,7 @@
         } ]
       }
     },
-    "/products/{productId}" : {
+    "/v1/products/{productId}" : {
       "get" : {
         "tags" : [ "product" ],
         "summary" : "getProduct",
@@ -991,7 +991,7 @@
         } ]
       }
     },
-    "/users" : {
+    "/v1/users" : {
       "post" : {
         "tags" : [ "external-v2", "support", "users" ],
         "summary" : "getUserInfo",
@@ -1053,7 +1053,7 @@
         } ]
       }
     },
-    "/users/{id}/onboarded-product" : {
+    "/v1/users/{id}/onboarded-product" : {
       "get" : {
         "tags" : [ "users" ],
         "summary" : "getUserProductInfo",

--- a/helm/pnpg/values-dev.yaml
+++ b/helm/pnpg/values-dev.yaml
@@ -11,7 +11,7 @@ ingress:
   hosts:
     - host: "dev01.pnpg.internal.dev.selfcare.pagopa.it"
       paths:
-        - path: /external-api/v1/(.*)
+        - path: /external-api/(.*)
           pathType: ImplementationSpecific
 
 autoscaling:

--- a/helm/pnpg/values-prod.yaml
+++ b/helm/pnpg/values-prod.yaml
@@ -13,7 +13,7 @@ ingress:
   hosts:
     - host: "prod01.pnpg.internal.selfcare.pagopa.it"
       paths:
-        - path: /external-api/v1/(.*)
+        - path: /external-api/(.*)
           pathType: ImplementationSpecific
 
 autoscaling:

--- a/helm/pnpg/values-uat.yaml
+++ b/helm/pnpg/values-uat.yaml
@@ -12,7 +12,7 @@ ingress:
   hosts:
     - host: "uat01.pnpg.internal.uat.selfcare.pagopa.it"
       paths:
-        - path: /external-api/v1/(.*)
+        - path: /external-api/(.*)
           pathType: ImplementationSpecific
 
 autoscaling:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -13,7 +13,7 @@ ingress:
   hosts:
     - host: selc.internal.dev.selfcare.pagopa.it
       paths:
-        - path: /external-api/v1/(.*)
+        - path: /external-api/(.*)
           pathType: ImplementationSpecific
 
 resources:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -15,7 +15,7 @@ ingress:
   hosts:
     - host: selc.internal.selfcare.pagopa.it
       paths:
-        - path: /external-api/v1/(.*)
+        - path: /external-api/(.*)
           pathType: ImplementationSpecific
 
 autoscaling:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -14,7 +14,7 @@ ingress:
   hosts:
     - host: selc.internal.uat.selfcare.pagopa.it
       paths:
-        - path: /external-api/v1/(.*)
+        - path: /external-api/(.*)
           pathType: ImplementationSpecific
 
 resources:

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/InstitutionController.java
@@ -38,7 +38,7 @@ import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM_VALUE;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/institutions", produces = APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/v1/institutions", produces = APPLICATION_JSON_VALUE)
 @Api(tags = "institutions")
 public class InstitutionController {
 

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/OnboardingController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/OnboardingController.java
@@ -35,7 +35,7 @@ import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/onboarding", produces = APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/v1/onboarding", produces = APPLICATION_JSON_VALUE)
 @Api(tags = "onboarding")
 public class OnboardingController {
 

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/PnPgController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/PnPgController.java
@@ -19,7 +19,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/pn-pg", produces = APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/v1/pn-pg", produces = APPLICATION_JSON_VALUE)
 @Api(tags = "institutions-pnpg")
 public class PnPgController {
     private final InstitutionService institutionService;

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/ProductController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/ProductController.java
@@ -16,7 +16,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/products", produces = APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/v1/products", produces = APPLICATION_JSON_VALUE)
 @Api(tags = "product")
 public class ProductController {
 

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/UserController.java
@@ -22,7 +22,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/users", produces = APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/v1/users", produces = APPLICATION_JSON_VALUE)
 @Api(tags = "users")
 public class UserController {
 

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/InstitutionControllerTest.java
@@ -49,7 +49,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = {InstitutionController.class}, excludeAutoConfiguration = SecurityAutoConfiguration.class)
 @ContextConfiguration(classes = {InstitutionController.class, WebTestConfig.class, InstitutionResourceMapperImpl.class})
 class InstitutionControllerTest {
-    private static final String BASE_URL = "/institutions";
+    private static final String BASE_URL = "/v1/institutions";
 
     @Autowired
     protected MockMvc mvc;

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/OnboardingControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/OnboardingControllerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = {OnboardingController.class, WebTestConfig.class, OnboardingResourceMapperImpl.class})
 class OnboardingControllerTest {
 
-    private static final String BASE_URL = "/onboarding";
+    private static final String BASE_URL = "/v1/onboarding";
     public static final String FIELD_PSP_DATA_IS_REQUIRED_FOR_PSP_INSTITUTION_ONBOARDING = "Field 'pspData' is required for PSP institution onboarding";
 
     @Autowired

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/PnPgControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/PnPgControllerTest.java
@@ -36,7 +36,7 @@ class PnPgControllerTest {
 
     @MockBean
     private InstitutionService institutionServiceMock;
-    private final static String BASE_URL = "/pn-pg";
+    private final static String BASE_URL = "/v1/pn-pg";
 
     @Test
     void addInstitution() throws Exception {

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/ProductControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/ProductControllerTest.java
@@ -34,7 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = {ProductController.class}, excludeAutoConfiguration = SecurityAutoConfiguration.class)
 @ContextConfiguration(classes = {ProductController.class, WebTestConfig.class})
 public class ProductControllerTest {
-    private static final String BASE_URL = "/products";
+    private static final String BASE_URL = "/v1/products";
 
     @Autowired
     protected MockMvc mvc;

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/UserControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/UserControllerTest.java
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = {UserController.class, WebTestConfig.class, UserInfoResourceMapperImpl.class})
 class UserControllerTest {
 
-    private static final String BASE_URL = "/users";
+    private static final String BASE_URL = "/v1/users";
     private static final String fiscalCode = "MNCCSD01R13A757G";
 
     @Autowired


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Remove /v1 prefix at helm file
Added /v1 prefix to web controller

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

/v1 prefix at helm value does not permit to add a new version of the endpoint, for example /v2/onboarding. Moving the prefix to controller enable possibility to create a new version of web controllers.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.