### PR TITLE
[SELC-4033] feat: added v2 for oldContractOnboarding

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -841,6 +841,7 @@
             }
           }
         },
+        "deprecated" : true,
         "security" : [ {
           "bearerAuth" : [ "global" ]
         } ]
@@ -1001,6 +1002,92 @@
             }
           }
         },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/v2/onboarding/{externalInstitutionId}" : {
+      "post" : {
+        "tags" : [ "onboarding" ],
+        "summary" : "oldContractOnboarding",
+        "description" : "The service allows the import of old institutions' contracts",
+        "operationId" : "oldContractOnboardingUsingPOST_1",
+        "parameters" : [ {
+          "name" : "externalInstitutionId",
+          "in" : "path",
+          "description" : "Institution's unique external identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OnboardingImportDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "deprecated" : true,
         "security" : [ {
           "bearerAuth" : [ "global" ]
         } ]

--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/OnboardingData.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/OnboardingData.java
@@ -28,6 +28,7 @@ public class OnboardingData {
     private RootParent rootParent;
     private Boolean sendCompleteOnboardingEmail;
     private InstitutionLocation location;
+    private OnboardingImportContract contractImported;
 
     public List<User> getUsers() {
         return Optional.ofNullable(users).orElse(Collections.emptyList());

--- a/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/mapper/OnboardingMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/mapper/OnboardingMapper.java
@@ -10,6 +10,8 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -18,14 +20,21 @@ import java.util.stream.Collectors;
 public interface OnboardingMapper {
 
     @Mapping(target = "institution", source = ".", qualifiedByName = "toInstitutionBase")
+    @Mapping(target = "contractImported", ignore = true)
     OnboardingPaRequest toOnboardingPaRequest(OnboardingData onboardingData);
     @Mapping(target = "institution", source = ".", qualifiedByName = "toInstitutionPsp")
+    @Mapping(target = "contractImported", ignore = true)
     OnboardingPspRequest toOnboardingPspRequest(OnboardingData onboardingData);
     @Mapping(target = "institution", source = ".", qualifiedByName = "toInstitutionBase")
+    @Mapping(target = "contractImported.createdAt", source = "contractImported.createdAt", qualifiedByName = "convertDate")
     OnboardingDefaultRequest toOnboardingDefaultRequest(OnboardingData onboardingData);
 
     GeographicTaxonomyDto toGeographicTaxonomyDto(GeographicTaxonomy geographicTaxonomy);
 
+    @Named("convertDate")
+    default LocalDateTime convertDate(OffsetDateTime date) {
+        return date.toLocalDateTime();
+    }
     @Named("toInstitutionBase")
     default InstitutionBaseRequest toInstitutionBase(OnboardingData onboardingData) {
         InstitutionBaseRequest institution = new InstitutionBaseRequest();

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/OnboardingController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/OnboardingController.java
@@ -52,6 +52,7 @@ public class OnboardingController {
         this.onboardingResourceMapper = onboardingResourceMapper;
     }
 
+    @Deprecated(forRemoval = true)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "409",
                     description = "Conflict",

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/OnboardingV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/OnboardingV2Controller.java
@@ -2,12 +2,16 @@ package it.pagopa.selfcare.external_api.web.controller;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import it.pagopa.selfcare.commons.web.model.Problem;
 import it.pagopa.selfcare.external_api.core.OnboardingService;
+import it.pagopa.selfcare.external_api.web.model.mapper.OnboardingMapper;
 import it.pagopa.selfcare.external_api.web.model.mapper.OnboardingResourceMapper;
+import it.pagopa.selfcare.external_api.web.model.onboarding.OnboardingImportDto;
 import it.pagopa.selfcare.external_api.web.model.onboarding.OnboardingProductDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +19,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.ValidationException;
+
+import java.time.OffsetDateTime;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
@@ -27,9 +34,6 @@ public class OnboardingV2Controller {
 
     private final OnboardingService onboardingService;
     private final OnboardingResourceMapper onboardingResourceMapper;
-
-    protected static final String LOCATION_INFO_IS_REQUIRED = "Field 'Location' is required";
-
 
     @Autowired
     public OnboardingV2Controller(OnboardingService onboardingService,
@@ -52,6 +56,39 @@ public class OnboardingV2Controller {
         log.debug("onboarding request = {}", request);
         onboardingService.autoApprovalOnboardingProductV2(onboardingResourceMapper.toEntity(request));
         log.trace("onboarding end");
+    }
+
+    @Deprecated(forRemoval = true)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "409",
+                    description = "Conflict",
+                    content = {
+                            @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE,
+                                    schema = @Schema(implementation = Problem.class))
+                    }),
+            @ApiResponse(responseCode = "403",
+                    description = "Forbidden",
+                    content = {
+                            @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE,
+                                    schema = @Schema(implementation = Problem.class))
+                    })
+    })
+    @PostMapping(value = "/{externalInstitutionId}")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "", notes = "${swagger.external_api.onboarding.api.onboardingOldContract}")
+    public void oldContractOnboarding(@ApiParam("${swagger.external_api.institutions.model.externalId}")
+                                      @PathVariable("externalInstitutionId")
+                                      String externalInstitutionId,
+                                      @RequestBody
+                                      @Valid
+                                      OnboardingImportDto request) {
+        log.trace("oldContractonboarding start");
+        log.debug("oldContractonboarding institutionId = {}, request = {}", externalInstitutionId, request);
+        if (request.getImportContract().getOnboardingDate().compareTo(OffsetDateTime.now()) > 0) {
+            throw new ValidationException("Invalid onboarding date: the onboarding date must be prior to the current date.");
+        }
+        onboardingService.autoApprovalOnboardingProductV2(OnboardingMapper.toOnboardingData(externalInstitutionId, request));
+        log.trace("oldContractonboarding end");
     }
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/model/mapper/OnboardingMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/model/mapper/OnboardingMapper.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.external_api.web.model.mapper;
 
 
-import io.jsonwebtoken.lang.Assert;
+import it.pagopa.selfcare.commons.base.utils.ProductId;
 import it.pagopa.selfcare.external_api.model.onboarding.*;
 import it.pagopa.selfcare.external_api.web.model.onboarding.*;
 import lombok.AccessLevel;
@@ -49,7 +49,24 @@ public class OnboardingMapper {
         if (model != null) {
             resource = new OnboardingImportData();
             resource.setInstitutionExternalId(externalId);
-            resource.setProductId("prod-io");
+            resource.setProductId(ProductId.PROD_IO.getValue());
+            resource.setUsers(model.getUsers().stream()
+                    .map(UserMapper::toUser)
+                    .collect(Collectors.toList()));
+            resource.setContractImported(fromDto(model.getImportContract()));
+            resource.setBilling(new Billing());
+            resource.setInstitutionUpdate(new InstitutionUpdate());
+            resource.getInstitutionUpdate().setImported(true);
+        }
+        return resource;
+    }
+
+    public static OnboardingData toOnboardingData(String externalId, OnboardingImportDto model) {
+        OnboardingData resource = null;
+        if (model != null) {
+            resource = new OnboardingData();
+            resource.setInstitutionExternalId(externalId);
+            resource.setProductId(ProductId.PROD_IO.getValue());
             resource.setUsers(model.getUsers().stream()
                     .map(UserMapper::toUser)
                     .collect(Collectors.toList()));

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/OnboardingV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/OnboardingV2ControllerTest.java
@@ -49,4 +49,22 @@ public class OnboardingV2ControllerTest {
                 .autoApprovalOnboardingProductV2(any(OnboardingData.class));
         verifyNoMoreInteractions(onboardingServiceMock);
     }
+
+    @Test
+    void oldContractOnboarding(@Value("classpath:stubs/onboardingImportDto.json") Resource onboardingImportDto) throws Exception {
+        // given
+        String institutionId = "institutionId";
+        // when
+        mvc.perform(MockMvcRequestBuilders
+                        .post(BASE_URL + "/{institutionId}", institutionId)
+                        .content(onboardingImportDto.getInputStream().readAllBytes())
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().isCreated())
+                .andExpect(content().string(emptyString()));
+        // then
+        verify(onboardingServiceMock, times(1))
+                .autoApprovalOnboardingProductV2(any(OnboardingData.class));
+        verifyNoMoreInteractions(onboardingServiceMock);
+    }
 }

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/model/mapper/OnboardingMapperTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/model/mapper/OnboardingMapperTest.java
@@ -17,6 +17,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class OnboardingMapperTest {
 
+    private static final String PROD_IO = "prod-io";
+    private static final String INSTITUTION_ID = "institutionId";
+
     @Test
     void fromDtoImportContract() {
         //given
@@ -42,20 +45,19 @@ class OnboardingMapperTest {
     @Test
     void toOnboardingImportData() {
         //given
-        String institutionId = "institutionId";
         List<UserDto> userDtos = List.of(mockInstance(new UserDto()));
         ImportContractDto importContractDto = mockInstance(new ImportContractDto());
         OnboardingImportDto model = mockInstance(new OnboardingImportDto());
         model.setUsers(userDtos);
         model.setImportContract(importContractDto);
         //when
-        OnboardingImportData resource = OnboardingMapper.toOnboardingImportData(institutionId, model);
+        OnboardingImportData resource = OnboardingMapper.toOnboardingImportData(INSTITUTION_ID, model);
         //then
         assertNotNull(resource);
         assertEquals(model.getUsers().size(), resource.getUsers().size());
-        assertEquals(institutionId, resource.getInstitutionExternalId());
+        assertEquals(INSTITUTION_ID, resource.getInstitutionExternalId());
         assertTrue(resource.getInstitutionUpdate().getImported());
-        assertEquals("prod-io", resource.getProductId());
+        assertEquals(PROD_IO, resource.getProductId());
         assertTrue(resource.getInstitutionUpdate().getImported());
         assertNull(resource.getInstitutionType());
         reflectionEqualsByName(userDtos.get(0), resource.getUsers().get(0));
@@ -63,12 +65,33 @@ class OnboardingMapperTest {
     }
 
     @Test
+    void toOnboardingDataWithContract() {
+        //given
+        List<UserDto> users = List.of(mockInstance(new UserDto()));
+        ImportContractDto importContractDto = mockInstance(new ImportContractDto());
+        OnboardingImportDto model = mockInstance(new OnboardingImportDto());
+        model.setUsers(users);
+        model.setImportContract(importContractDto);
+        //when
+        OnboardingData resource = OnboardingMapper.toOnboardingData(INSTITUTION_ID, model);
+        //then
+        assertNotNull(resource);
+        assertEquals(model.getUsers().size(), resource.getUsers().size());
+        assertEquals(INSTITUTION_ID, resource.getInstitutionExternalId());
+        assertTrue(resource.getInstitutionUpdate().getImported());
+        assertEquals(PROD_IO, resource.getProductId());
+        assertTrue(resource.getInstitutionUpdate().getImported());
+        assertNull(resource.getInstitutionType());
+        reflectionEqualsByName(users.get(0), resource.getUsers().get(0));
+        reflectionEqualsByName(importContractDto, resource.getContractImported());
+    }
+
+    @Test
     void toOnboardingImportData_null() {
         //given
-        String institutionId = "institutionId";
         OnboardingImportDto onboardingDto = null;
         //when
-        OnboardingImportData resource = OnboardingMapper.toOnboardingImportData(institutionId, onboardingDto);
+        OnboardingImportData resource = OnboardingMapper.toOnboardingImportData(INSTITUTION_ID, onboardingDto);
         //then
         assertNull(resource);
     }
@@ -97,8 +120,7 @@ class OnboardingMapperTest {
     @Test
     void toOnboardingData() {
         //given
-        String institutionId = "institutionId";
-        String productId = "productId";
+        String productId = PROD_IO;
         List<UserDto> userDtos = List.of(mockInstance(new UserDto()));
         OnboardingDto model = mockInstance(new OnboardingDto());
         BillingDataDto billingDataDto = mockInstance(new BillingDataDto());
@@ -109,12 +131,12 @@ class OnboardingMapperTest {
         model.setPspData(pspDataDto);
         model.setGeographicTaxonomies(geographicTaxonomyDtos);
         //when
-        OnboardingData resource = OnboardingMapper.toOnboardingData(institutionId, productId, model);
+        OnboardingData resource = OnboardingMapper.toOnboardingData(INSTITUTION_ID, productId, model);
         //then
         assertNotNull(resource);
         assertEquals(model.getUsers().size(), resource.getUsers().size());
         assertEquals(model.getGeographicTaxonomies().size(), resource.getInstitutionUpdate().getGeographicTaxonomies().size());
-        assertEquals(institutionId, resource.getInstitutionExternalId());
+        assertEquals(INSTITUTION_ID, resource.getInstitutionExternalId());
         assertEquals(productId, resource.getProductId());
         reflectionEqualsByName(billingDataDto, resource.getBilling());
         reflectionEqualsByName(userDtos.get(0), resource.getUsers().get(0));


### PR DESCRIPTION
#### List of Changes

Added a new endpoint, version v2 GET **/onboarding/{externalId}**, which is designed to process onboarding. This endpoint triggers the new onboarding service

#### Motivation and Context

The existing onboarding process redirects to old onboarding service.

