### PR TITLE
[SELC-4086] fix: Update field status in TokenResource

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2660,8 +2660,7 @@
             "type" : "string"
           },
           "status" : {
-            "type" : "string",
-            "enum" : [ "ACTIVE", "DELETED", "PENDING", "REJECTED", "SUSPENDED", "TOBEVALIDATED" ]
+            "type" : "string"
           },
           "updatedAt" : {
             "type" : "string",

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/model/tokens/TokenResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/model/tokens/TokenResource.java
@@ -20,7 +20,7 @@ public class TokenResource {
     private String id;
     private String checksum;
     private List<LegalsResource> legals = new ArrayList<>();
-    private RelationshipState status;
+    private String status;
     private String institutionId;
     private String productId;
     private OffsetDateTime expiringDate;


### PR DESCRIPTION
#### List of Changes

Update field status in TokenResource

#### Motivation and Context

In order to avoid conflicts with enum ReationshipState, the field status is changed into String. In this way is possible to manage new statuses such as COMPLETED
