### PR TITLE
[SELC-4033] fix: Update oldContractOnboarding to invoke new onboading-ms

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1090,7 +1090,6 @@
             }
           }
         },
-        "deprecated" : true,
         "security" : [ {
           "bearerAuth" : [ "global" ]
         } ]

--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/api/OnboardingMsConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/api/OnboardingMsConnector.java
@@ -10,6 +10,7 @@ public interface OnboardingMsConnector {
 
     List<Token> getToken(String onboardingId);
     void onboarding(OnboardingData onboardingData);
+    void onboardingImportPA(OnboardingData onboardingData);
     List<TokenOnboardedUsers> getOnboardings(String productId, int page, int size);
 
 }

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -113,6 +113,46 @@
         } ]
       }
     },
+    "/v1/onboarding/pa/import": {
+      "post": {
+        "tags": [
+          "Onboarding Controller"
+        ],
+        "summary": "Perform onboarding as /onboarding/pa but create token and completing the onboarding request to COMPLETED phase.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OnboardingImportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OnboardingResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      }
+    },
     "/v1/onboarding/completion" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
@@ -1264,6 +1304,103 @@
           },
           "productRole" : {
             "type" : "string"
+          }
+        }
+      },
+      "InstitutionImportRequest": {
+        "required": [
+          "taxCode"
+        ],
+        "type": "object",
+        "properties": {
+          "institutionType": {
+            "$ref": "#/components/schemas/InstitutionType"
+          },
+          "taxCode": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "subunitCode": {
+            "type": "string"
+          },
+          "subunitType": {
+            "$ref": "#/components/schemas/InstitutionPaSubunitType"
+          },
+          "origin": {
+            "$ref": "#/components/schemas/Origin"
+          },
+          "city": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "county": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "digitalAddress": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "zipCode": {
+            "type": "string"
+          },
+          "geographicTaxonomies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeographicTaxonomyDto"
+            }
+          },
+          "rea": {
+            "type": "string"
+          },
+          "shareCapital": {
+            "type": "string"
+          },
+          "businessRegisterPlace": {
+            "type": "string"
+          },
+          "supportEmail": {
+            "type": "string"
+          },
+          "supportPhone": {
+            "type": "string"
+          },
+          "imported": {
+            "type": "boolean"
+          }
+        }
+      },
+      "OnboardingImportRequest": {
+        "required": [
+          "institution",
+          "productId",
+          "users",
+          "contractImported"
+        ],
+        "type": "object",
+        "properties": {
+          "institution": {
+            "$ref": "#/components/schemas/InstitutionImportRequest"
+          },
+          "productId": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "users": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserRequest"
+            }
+          },
+          "contractImported": {
+            "$ref": "#/components/schemas/OnboardingImportContract"
           }
         }
       },

--- a/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/OnboardingMsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/OnboardingMsConnectorImpl.java
@@ -9,7 +9,6 @@ import it.pagopa.selfcare.external_api.connector.rest.mapper.TokenMapper;
 import it.pagopa.selfcare.external_api.model.onboarding.OnboardingData;
 import it.pagopa.selfcare.external_api.model.token.Token;
 import it.pagopa.selfcare.external_api.model.token.TokenOnboardedUsers;
-import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingGetResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -51,6 +50,11 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
         } else {
             onboardingControllerApi._v1OnboardingCompletionPost(onboardingMapper.toOnboardingDefaultRequest(onboardingData));
         }
+    }
+
+    @Override
+    public void onboardingImportPA(OnboardingData onboardingData) {
+        onboardingControllerApi._v1OnboardingPaImportPost(onboardingMapper.toOnboardingImportRequest(onboardingData));
     }
 
     @Override

--- a/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/mapper/OnboardingMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/mapper/OnboardingMapper.java
@@ -28,7 +28,10 @@ public interface OnboardingMapper {
     @Mapping(target = "institution", source = ".", qualifiedByName = "toInstitutionBase")
     @Mapping(target = "contractImported.createdAt", source = "contractImported.createdAt", qualifiedByName = "convertDate")
     OnboardingDefaultRequest toOnboardingDefaultRequest(OnboardingData onboardingData);
-
+    @Mapping(target = "institution", source = "institutionUpdate")
+    @Mapping(target = "institution.institutionType", ignore = true)
+    @Mapping(target = "contractImported.createdAt", source = "contractImported.createdAt", qualifiedByName = "convertDate")
+    OnboardingImportRequest toOnboardingImportRequest(OnboardingData onboardingData);
     GeographicTaxonomyDto toGeographicTaxonomyDto(GeographicTaxonomy geographicTaxonomy);
 
     @Named("convertDate")

--- a/connector/rest/src/main/resources/config/ms-onboarding-rest-client.properties
+++ b/connector/rest/src/main/resources/config/ms-onboarding-rest-client.properties
@@ -1,4 +1,4 @@
-rest-client.ms-onboarding.base-url=${MS_ONBOARDING_URL:https://selc-d-onboarding-ms-ca.gentleflower-c63e62fe.westeurope.azurecontainerapps.io}
+rest-client.ms-onboarding.base-url=${MS_ONBOARDING_URL:http://localhost:8080}
 rest-client.ms-onboarding-token-api.serviceCode=ms-onboarding-token-api
 rest-client.ms-onboarding-api.serviceCode=ms-onboarding-api
 feign.client.config.ms-onboarding-token-api.requestInterceptors[0]=it.pagopa.selfcare.commons.connector.rest.interceptor.AuthorizationHeaderInterceptor

--- a/connector/rest/src/test/java/it/pagopa/selfcare/external_api/connector/rest/OnboardingMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/external_api/connector/rest/OnboardingMsConnectorImplTest.java
@@ -8,10 +8,7 @@ import it.pagopa.selfcare.external_api.connector.rest.mapper.OnboardingMapperImp
 import it.pagopa.selfcare.external_api.connector.rest.mapper.TokenMapper;
 import it.pagopa.selfcare.external_api.connector.rest.mapper.TokenMapperImpl;
 import it.pagopa.selfcare.external_api.model.onboarding.*;
-import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingDefaultRequest;
-import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingPaRequest;
-import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingPspRequest;
-import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.TokenResponse;
+import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -135,6 +132,26 @@ public class OnboardingMsConnectorImplTest {
         assertEquals(actual.getInstitution().getTaxCode(), institutionUpdate.getTaxCode());
         assertNotNull(actual.getInstitution().getPaymentServiceProvider());
         assertNotNull(actual.getInstitution().getDataProtectionOfficer());
+        verifyNoMoreInteractions(onboardingControllerApi);
+    }
+
+    @Test
+    void onboarding_importPa() {
+        // given
+        OnboardingData onboardingData = new OnboardingData();
+        onboardingData.setTaxCode("taxCode");
+        InstitutionUpdate institutionUpdate = new InstitutionUpdate();
+        institutionUpdate.setTaxCode("taxCode");
+        onboardingData.setUsers(List.of(mockInstance(new User())));
+        onboardingData.setInstitutionUpdate(institutionUpdate);
+        // when
+        onboardingMsConnector.onboardingImportPA(onboardingData);
+        // then
+        ArgumentCaptor<OnboardingImportRequest> onboardingRequestCaptor = ArgumentCaptor.forClass(OnboardingImportRequest.class);
+        verify(onboardingControllerApi, times(1))
+                ._v1OnboardingPaImportPost(onboardingRequestCaptor.capture());
+        OnboardingImportRequest actual = onboardingRequestCaptor.getValue();
+        assertEquals(actual.getInstitution().getTaxCode(), institutionUpdate.getTaxCode());
         verifyNoMoreInteractions(onboardingControllerApi);
     }
 }

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/OnboardingService.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/OnboardingService.java
@@ -8,6 +8,8 @@ public interface OnboardingService {
 
     void oldContractOnboarding(OnboardingImportData onboardingData);
 
+    void oldContractOnboardingV2(OnboardingData onboardingData);
+
     void autoApprovalOnboarding(OnboardingData onboardingData);
 
     void autoApprovalOnboardingFromPda(PdaOnboardingData onboardingData, String injestionInstitutionType);

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/OnboardingServiceImpl.java
@@ -187,6 +187,14 @@ class OnboardingServiceImpl implements OnboardingService {
     }
 
     @Override
+    public void oldContractOnboardingV2(OnboardingData onboardingImportData) {
+        log.trace("oldContractOnboarding start");
+        log.debug("oldContractOnboarding = {}", onboardingImportData);
+        onboardingMsConnector.onboardingImportPA(onboardingImportData);
+        log.trace("oldContractOnboarding end");
+    }
+
+    @Override
     public void autoApprovalOnboarding(OnboardingData onboardingData) {
         log.trace("autoApprovalOnboarding start");
         log.debug("autoApprovalOnboarding = {}", onboardingData);

--- a/core/src/test/java/it/pagopa/selfcare/external_api/core/OnboardingServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/external_api/core/OnboardingServiceImplTest.java
@@ -3826,4 +3826,16 @@ class OnboardingServiceImplTest {
                 .onboarding(any());
     }
 
+    @Test
+    void onboardingImportPa() {
+        // given
+        OnboardingData onboardingData = mockInstance(new OnboardingData(), "setInstitutionType", "setUsers");
+        onboardingData.setUsers(List.of(dummyManager, dummyDelegate));
+        // when
+        onboardingServiceImpl.oldContractOnboardingV2(onboardingData);
+        // then
+        verify(onboardingMsConnectorMock, times(1))
+                .onboardingImportPA(any());
+    }
+
 }

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/OnboardingV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/OnboardingV2Controller.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.ValidationException;
-
 import java.time.OffsetDateTime;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -58,7 +57,6 @@ public class OnboardingV2Controller {
         log.trace("onboarding end");
     }
 
-    @Deprecated(forRemoval = true)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "409",
                     description = "Conflict",
@@ -87,7 +85,7 @@ public class OnboardingV2Controller {
         if (request.getImportContract().getOnboardingDate().compareTo(OffsetDateTime.now()) > 0) {
             throw new ValidationException("Invalid onboarding date: the onboarding date must be prior to the current date.");
         }
-        onboardingService.autoApprovalOnboardingProductV2(OnboardingMapper.toOnboardingData(externalInstitutionId, request));
+        onboardingService.oldContractOnboardingV2(OnboardingMapper.toOnboardingData(externalInstitutionId, request));
         log.trace("oldContractonboarding end");
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/model/mapper/OnboardingMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/model/mapper/OnboardingMapper.java
@@ -73,6 +73,7 @@ public class OnboardingMapper {
             resource.setContractImported(fromDto(model.getImportContract()));
             resource.setBilling(new Billing());
             resource.setInstitutionUpdate(new InstitutionUpdate());
+            resource.getInstitutionUpdate().setTaxCode(externalId);
             resource.getInstitutionUpdate().setImported(true);
         }
         return resource;

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/OnboardingV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/OnboardingV2ControllerTest.java
@@ -64,7 +64,7 @@ public class OnboardingV2ControllerTest {
                 .andExpect(content().string(emptyString()));
         // then
         verify(onboardingServiceMock, times(1))
-                .autoApprovalOnboardingProductV2(any(OnboardingData.class));
+                .oldContractOnboardingV2(any(OnboardingData.class));
         verifyNoMoreInteractions(onboardingServiceMock);
     }
 }


### PR DESCRIPTION

#### List of Changes

Added a new endpoint, version v2 GET /onboarding/{externalId}, which is designed to process onboarding. This endpoint triggers the new onboarding service

#### Motivation and Context

The existing onboarding process redirects to old onboarding service.

#### How Has This Been Tested?

I have run both microservices - onboarding and external-api - locally and tested the api for oldContractOnboarding