### PR TITLE
hotfix: endpoint getInstitutionProductUsersV2 when user is null

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/user/UserInstitution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/user/UserInstitution.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class UserInstitution {
     private String institutionId;
 
+    private String userId;
     private String userMailUuid;
 
     @Valid


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Fix v2 version of getInstitutionProductUsers that retrieve data from user-ms for permitting userId filter is null

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.