### PR TITLE
[SELC-4842] fix: if signed empty throw resource not found

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/ContractServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/ContractServiceImpl.java
@@ -11,6 +11,7 @@ import it.pagopa.selfcare.external_api.model.onboarding.InstitutionOnboarding;
 import it.pagopa.selfcare.external_api.model.token.Token;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -18,6 +19,8 @@ import java.util.Objects;
 @Service
 @Slf4j
 public class ContractServiceImpl implements ContractService {
+    public static final String TOKEN_FOR_S_AND_S_FOUND_BUT_CONTRACT_SIGNED_REFERENCE_IS_EMPTY = "Token for %s and %s found but contract signed reference is empty!";
+    public static final String TOKEN_FOR_S_AND_S_NOT_FOUND = "Token for %s and %s not found!";
     private final FileStorageConnector fileStorageConnector;
     private final MsCoreConnector msCoreConnector;
     private final OnboardingMsConnector onboardingMsConnector;
@@ -38,7 +41,9 @@ public class ContractServiceImpl implements ContractService {
 
         List<Token> tokens = onboardingMsConnector.getToken(institutionOnboarding.getTokenId());
         if(Objects.isNull(tokens) || tokens.isEmpty())
-            throw new ResourceNotFoundException("Token not found!");
+            throw new ResourceNotFoundException(String.format(TOKEN_FOR_S_AND_S_NOT_FOUND, institutionId, productId));
+        if(!StringUtils.hasText(tokens.get(0).getContractSigned()))
+            throw new ResourceNotFoundException(String.format(TOKEN_FOR_S_AND_S_FOUND_BUT_CONTRACT_SIGNED_REFERENCE_IS_EMPTY, institutionId, productId));
         ResourceResponse file = fileStorageConnector.getFile(tokens.get(0).getContractSigned());
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "getContract result = {}", file);
         log.trace("getContract end");


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Added check on get contract when contractSigned is empty

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

contractSigned could be empty and some errors 500 occur 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.