### PR TITLE
hotfix: Fix user email retrieval logic in the GET institutions//{institutionId}/products/{productId}/users

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/user/UserInfo.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/user/UserInfo.java
@@ -33,6 +33,7 @@ public class UserInfo {
     private Map<String, ProductInfo> products;
     private String status;
     private String institutionId;
+    private String userUuidMail;
 
 
     @Data

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImpl.java
@@ -195,6 +195,7 @@ class InstitutionServiceImpl implements InstitutionService {
         products.put(productInfo.getId(), productInfo);
         userInfo.setProducts(products);
         userInfo.setInstitutionId(userInstitution.getInstitutionId());
+        userInfo.setUserUuidMail(userInstitution.getUserMailUuid());
         return userInfo;
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/model/mapper/UserMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/model/mapper/UserMapper.java
@@ -33,7 +33,8 @@ public class UserMapper {
                         .map(RoleInfo::getRole)
                         .collect(Collectors.toList()));
                 Optional.ofNullable(model.getUser().getWorkContacts())
-                        .map(map -> map.get(model.getInstitutionId()))
+                        .filter(map -> map.containsKey(model.getUserUuidMail()))
+                        .map(map -> map.get(model.getUserUuidMail()))
                         .map(WorkContact::getEmail)
                         .map(CertifiedFieldMapper::toValue)
                         .ifPresent(resource::setEmail);

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/model/mapper/UserMapperTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/model/mapper/UserMapperTest.java
@@ -43,7 +43,7 @@ class UserMapperTest {
         Map<String, ProductInfo> product = new HashMap<>();
         product.put(productMock.getId(), productMock);
         model.setProducts(product);
-        model.getUser().setWorkContacts(Map.of(model.getInstitutionId(), mockInstance(new WorkContact())));
+        model.getUser().setWorkContacts(Map.of(model.getUserUuidMail(), mockInstance(new WorkContact())));
         String id = model.getProducts().keySet().toArray()[0].toString();
         ProductInfo productInfo = model.getProducts().get(id);
         // when
@@ -52,7 +52,7 @@ class UserMapperTest {
         assertEquals(model.getId(), resource.getId().toString());
         assertEquals(model.getUser().getName().getValue(), resource.getName());
         assertEquals(model.getUser().getFamilyName().getValue(), resource.getSurname());
-        assertEquals(model.getUser().getWorkContacts().get(model.getInstitutionId()).getEmail().getValue(), resource.getEmail());
+        assertEquals(model.getUser().getWorkContacts().get(model.getUserUuidMail()).getEmail().getValue(), resource.getEmail());
         assertEquals(model.getPartyRole(), resource.getRole());
         assertIterableEquals(productInfo.getRoleInfos().stream().map(RoleInfo::getRole).collect(Collectors.toList()), resource.getRoles());
     }

--- a/web/src/test/resources/expectations/UserInfo.json
+++ b/web/src/test/resources/expectations/UserInfo.json
@@ -1,0 +1,108 @@
+[
+  {
+    "id": "123e4567-e89b-12d3-a456-426614174000",
+    "user": {
+      "id": "123e4567-e89b-12d3-a456-426614174000",
+      "fiscalCode": "NLLGPJ67L30L783W",
+      "name": {
+        "value": "John"
+      },
+      "familyName": {
+        "value": "Doe"
+      },
+      "email": {
+        "value": "john.doe@example.com"
+      },
+      "workContacts": {
+        "institution1": {
+          "email": {
+            "value": "contact1@work.it"
+          }
+        },
+        "contact2": {
+          "email": {
+            "value": "contact2@work.it"
+          }
+        }
+      }
+    },
+    "role": "ADMIN",
+    "partyRole": "MANAGER",
+    "products": {
+      "testProductId": {
+        "id": "product1",
+        "title": "Product1",
+        "roleInfos": [
+          {
+            "relationshipId": "rel1",
+            "role": "role1",
+            "status": "ACTIVE",
+            "selcRole": "ADMIN"
+          },
+          {
+            "relationshipId": "rel2",
+            "role": "role2",
+            "status": "ACTIVE",
+            "selcRole": "ADMIN"
+          }
+        ]
+      }
+    },
+    "status": "ACTIVE",
+    "institutionId": "institution1",
+    "userUuidMail": "institution1"
+  },
+  {
+    "id": "123e4567-e89b-12d3-a456-426614174555",
+    "user": {
+      "id": "123e4567-e89b-12d3-a456-426614174555",
+      "fiscalCode": "NLLGPJ67L30L783S",
+      "name": {
+        "value": "John2"
+      },
+      "familyName": {
+        "value": "Doe2"
+      },
+      "email": {
+        "value": "john.doe@example.com"
+      },
+      "workContacts": {
+        "institution1": {
+          "email": {
+            "value": "contact1@work.it"
+          }
+        },
+        "contact2": {
+          "email": {
+            "value": "contact2@work.it"
+          }
+        }
+      }
+    },
+    "role": "ADMIN",
+    "partyRole": "MANAGER",
+    "products": {
+      "testProductId": {
+        "id": "product1",
+        "title": "Product1",
+        "roleInfos": [
+          {
+            "relationshipId": "rel1",
+            "role": "role1",
+            "status": "ACTIVE",
+            "selcRole": "ADMIN"
+          },
+          {
+            "relationshipId": "rel2",
+            "role": "role2",
+            "status": "ACTIVE",
+            "selcRole": "ADMIN"
+          }
+        ]
+      }
+    },
+    "status": "ACTIVE",
+    "institutionId": "institution1",
+    "userUuidMail": "institution1"
+  }
+]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Updated the email retrieval logic to use UserUuidMail removing the old logic that retrieved the email based on institutionId.
* Added necessary tests to ensure the new logic works as expected.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Addresses a bug in the business logic of the endpoint GET institutions//{institutionId}/products/{productId}/users. Previously, the email was being retrieved based on an outdated business logic using the institutionId. The fix updates the logic to correctly retrieve the user's email from the UserUuidMail data.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.