### PR TITLE
[SELC-4321] feat: handled http 400 status responses in feign decoder

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/exceptions/InvalidRequestException.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/exceptions/InvalidRequestException.java
@@ -1,0 +1,7 @@
+package it.pagopa.selfcare.external_api.exceptions;
+
+public class InvalidRequestException extends RuntimeException {
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/decoder/FeignErrorDecoder.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/decoder/FeignErrorDecoder.java
@@ -4,7 +4,10 @@ import feign.Request;
 import feign.Response;
 import feign.codec.ErrorDecoder;
 import it.pagopa.selfcare.external_api.exceptions.InstitutionDoesNotExistException;
+import it.pagopa.selfcare.external_api.exceptions.InvalidRequestException;
 import it.pagopa.selfcare.external_api.exceptions.ResourceNotFoundException;
+
+import java.util.Optional;
 
 public class FeignErrorDecoder extends ErrorDecoder.Default {
 
@@ -14,6 +17,9 @@ public class FeignErrorDecoder extends ErrorDecoder.Default {
             throw new ResourceNotFoundException(response.reason());
         } else if (response.status() == 400 && response.request().httpMethod().equals(Request.HttpMethod.HEAD)) {
             throw new InstitutionDoesNotExistException();
+        } else if(response.status() == 400) {
+            String errorMessage = Optional.ofNullable(response.body()).map(Object::toString).orElse(null);
+            throw new InvalidRequestException(errorMessage);
         } else {
             return super.decode(methodKey, response);
         }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/external_api/connector/rest/decoder/FeignErrorDecoderTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/external_api/connector/rest/decoder/FeignErrorDecoderTest.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.external_api.connector.rest.decoder;
 import feign.Request;
 import feign.Response;
 import it.pagopa.selfcare.external_api.exceptions.InstitutionDoesNotExistException;
+import it.pagopa.selfcare.external_api.exceptions.InvalidRequestException;
 import it.pagopa.selfcare.external_api.exceptions.ResourceNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -22,6 +23,22 @@ class FeignErrorDecoderTest {
     FeignErrorDecoder feignDecoder = new FeignErrorDecoder();
 
     private Map<String, Collection<String>> headers = new LinkedHashMap<>();
+
+    @Test
+    void testDecodeToInvalidRequest() throws Throwable {
+        //given
+        Response response = Response.builder()
+                .status(400)
+                .reason("Invalid Request")
+                .request(Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null, UTF_8))
+                .headers(headers)
+                .body("hello world", UTF_8)
+                .build();
+        //when
+        Executable executable = () -> feignDecoder.decode("", response);
+        //then
+        assertThrows(InvalidRequestException.class, executable);
+    }
 
     @Test
     void testDecodeToResourceNotFound() throws Throwable {
@@ -57,7 +74,6 @@ class FeignErrorDecoderTest {
 
     @ParameterizedTest
     @CsvSource(value = {
-            "BadRequest,400",
             "Unauthorized,401",
             "OK,200"
     })

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/handler/ExternalApiExceptionHandler.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/handler/ExternalApiExceptionHandler.java
@@ -5,6 +5,7 @@ import it.pagopa.selfcare.commons.web.model.mapper.ProblemMapper;
 import it.pagopa.selfcare.external_api.core.exception.OnboardingNotAllowedException;
 import it.pagopa.selfcare.external_api.core.exception.UpdateNotAllowedException;
 import it.pagopa.selfcare.external_api.exceptions.InstitutionAlreadyOnboardedException;
+import it.pagopa.selfcare.external_api.exceptions.InvalidRequestException;
 import it.pagopa.selfcare.external_api.exceptions.ResourceNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,11 @@ import static org.springframework.http.HttpStatus.*;
 @Slf4j
 @RestControllerAdvice
 public class ExternalApiExceptionHandler {
+    @ExceptionHandler({InvalidRequestException.class})
+    ResponseEntity<Problem> handleInvalidRequestException(InvalidRequestException e) {
+        log.warn(e.toString());
+        return ProblemMapper.toResponseEntity(new Problem(BAD_REQUEST, e.getMessage()));
+    }
 
     @ExceptionHandler(ResourceNotFoundException.class)
     ResponseEntity<Problem> handleNotFoundException(Exception e) {

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/handler/ExternalApiExceptionHandlerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/handler/ExternalApiExceptionHandlerTest.java
@@ -4,6 +4,7 @@ import it.pagopa.selfcare.commons.web.model.Problem;
 import it.pagopa.selfcare.external_api.core.exception.OnboardingNotAllowedException;
 import it.pagopa.selfcare.external_api.core.exception.UpdateNotAllowedException;
 import it.pagopa.selfcare.external_api.exceptions.InstitutionAlreadyOnboardedException;
+import it.pagopa.selfcare.external_api.exceptions.InvalidRequestException;
 import it.pagopa.selfcare.external_api.exceptions.ResourceNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,21 @@ class ExternalApiExceptionHandlerTest {
         this.handler = new ExternalApiExceptionHandler();
     }
 
+    @Test
+    void handleInvalidRequestException() {
+        //given
+        InvalidRequestException exceptionMock = mock(InvalidRequestException.class);
+        when(exceptionMock.getMessage())
+                .thenReturn(DETAIL_MESSAGE);
+        //when
+        ResponseEntity<Problem> responseEntity = handler.handleInvalidRequestException(exceptionMock);
+        //then
+        assertNotNull(responseEntity);
+        assertEquals(BAD_REQUEST, responseEntity.getStatusCode());
+        assertNotNull(responseEntity.getBody());
+        assertEquals(DETAIL_MESSAGE, responseEntity.getBody().getDetail());
+        assertEquals(BAD_REQUEST.value(), responseEntity.getBody().getStatus());
+    }
 
     @Test
     void handleResourceNotFoundException() {


### PR DESCRIPTION
#### List of Changes

Added in feign decoder the handling of http 400 response to throw appropriate exception

#### Motivation and Context

Before the intervention, API responses with http 400 status were not handled so the microservice always responded with http 500 status

#### How Has This Been Tested?
local env

#### Screenshots (if appropriate):


#### Checklist:


- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.