### PR TITLE
[SELC-5047] feat: Add userId Request Parameter to /institutions/{institutionId}/products Endpoint

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -407,15 +407,24 @@
     "/v2/institutions/{institutionId}/products" : {
       "get" : {
         "tags" : [ "external-v2" ],
-        "summary" : "getInstitutionUserProducts",
+        "summary" : "getInstitutionProducts",
         "description" : "Service to retrieve all active products for given institution and logged user",
-        "operationId" : "getInstitutionUserProductsUsingGET",
+        "operationId" : "getInstitutionProductsUsingGET",
         "parameters" : [ {
           "name" : "institutionId",
           "in" : "path",
           "description" : "Institution's unique internal Id",
           "required" : true,
           "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "userId",
+          "in" : "query",
+          "description" : "User's unique identifier",
+          "required" : true,
+          "style" : "form",
           "schema" : {
             "type" : "string"
           }

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/InstitutionService.java
@@ -16,7 +16,7 @@ import java.util.Set;
 public interface InstitutionService {
 
 
-    List<Product> getInstitutionUserProductsV2(String institutionId);
+    List<Product> getInstitutionUserProductsV2(String institutionId, String userId);
 
     Collection<UserInfo> getInstitutionProductUsersV2(String institutionId, String productId, String userId, Optional<Set<String>> productRoles, String xSelfCareUid);
 

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImpl.java
@@ -59,16 +59,13 @@ class InstitutionServiceImpl implements InstitutionService {
 
 
     @Override
-    public List<Product> getInstitutionUserProductsV2(String institutionId) {
+    public List<Product> getInstitutionUserProductsV2(String institutionId, String userId) {
         log.trace(TAG_LOG_INSTITUTION_USER_PRODUCTS + " start");
         Assert.hasText(institutionId, REQUIRED_INSTITUTION_MESSAGE);
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Assert.state(authentication != null, "Authentication is required");
-        Assert.state(authentication.getPrincipal() instanceof SelfCareUser, "Not SelfCareUser principal");
-        SelfCareUser user = (SelfCareUser) authentication.getPrincipal();
+
         List<Product> products = productsConnector.getProducts();
         if (!products.isEmpty()) {
-            List<String> productIds = msCoreConnector.getInstitutionUserProductsV2(institutionId, user.getId());
+            List<String> productIds = msCoreConnector.getInstitutionUserProductsV2(institutionId, userId);
             products = products.stream()
                     .filter(product -> productIds.contains(product.getId()))
                     .toList();

--- a/core/src/test/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImplTest.java
@@ -68,23 +68,6 @@ class InstitutionServiceImplTest extends BaseServiceTestUtils {
     }
 
     @Test
-    void getInstitutionUserProductsWithoutAuth() {
-        String institutionId = "institutionId";
-        Executable executable = () -> institutionService.getInstitutionUserProductsV2(institutionId);
-        IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, executable);
-        Assertions.assertEquals("Authentication is required", e.getMessage());
-    }
-
-    @Test
-    void getInstitutionUserProductsWithoutPrincipal() {
-        String institutionId = "institutionId";
-        TestSecurityContextHolder.setAuthentication(new TestingAuthenticationToken(null, null));
-        Executable executable = () -> institutionService.getInstitutionUserProductsV2(institutionId);
-        IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, executable);
-        Assertions.assertEquals("Not SelfCareUser principal", e.getMessage());
-    }
-
-    @Test
     void getInstitutionUserProductsWithProductEmpty() {
         String institutionId = "institutionId";
         PartyProduct partyProduct = new PartyProduct();
@@ -92,10 +75,8 @@ class InstitutionServiceImplTest extends BaseServiceTestUtils {
         partyProduct.setRole(PartyRole.MANAGER);
         partyProduct.setId("123");
         String userId = UUID.randomUUID().toString();
-        SelfCareUser selfCareUser = SelfCareUser.builder(userId).email("test@example.com").name("name").surname("surname").build();
-        TestSecurityContextHolder.setAuthentication(new TestingAuthenticationToken(selfCareUser, null));
         when(productsConnectorMock.getProducts()).thenReturn(Collections.emptyList());
-        List<Product> expectation = institutionService.getInstitutionUserProductsV2(institutionId);
+        List<Product> expectation = institutionService.getInstitutionUserProductsV2(institutionId, userId);
         Assertions.assertEquals(0, expectation.size());
     }
 
@@ -110,11 +91,9 @@ class InstitutionServiceImplTest extends BaseServiceTestUtils {
         partyProduct.setRole(PartyRole.MANAGER);
         partyProduct.setId("123");
         String userId = UUID.randomUUID().toString();
-        SelfCareUser selfCareUser = SelfCareUser.builder(userId).email("test@example.com").name("name").surname("surname").build();
-        TestSecurityContextHolder.setAuthentication(new TestingAuthenticationToken(selfCareUser, null));
         when(productsConnectorMock.getProducts()).thenReturn(products);
-        when(msCoreConnectorMock.getInstitutionUserProductsV2(institutionId, selfCareUser.getId())).thenReturn(List.of(partyProduct.getId()));
-        List<Product> expectation = institutionService.getInstitutionUserProductsV2(institutionId);
+        when(msCoreConnectorMock.getInstitutionUserProductsV2(institutionId, userId)).thenReturn(List.of(partyProduct.getId()));
+        List<Product> expectation = institutionService.getInstitutionUserProductsV2(institutionId, userId);
         Assertions.assertEquals(1, expectation.size());
         Assertions.assertEquals(expectation.get(0), products.get(0));
         Mockito.verify(msCoreConnectorMock, Mockito.times(1)).getInstitutionUserProductsV2(institutionId, userId);
@@ -139,11 +118,9 @@ class InstitutionServiceImplTest extends BaseServiceTestUtils {
         partyProduct2.setId("321");
 
         String userId = UUID.randomUUID().toString();
-        SelfCareUser selfCareUser = SelfCareUser.builder(userId).email("test@example.com").name("name").surname("surname").build();
-        TestSecurityContextHolder.setAuthentication(new TestingAuthenticationToken(selfCareUser, null));
         when(productsConnectorMock.getProducts()).thenReturn(products);
-        when(msCoreConnectorMock.getInstitutionUserProductsV2(institutionId, selfCareUser.getId())).thenReturn(List.of(partyProduct.getId(), partyProduct2.getId()));
-        List<Product> expectation = institutionService.getInstitutionUserProductsV2(institutionId);
+        when(msCoreConnectorMock.getInstitutionUserProductsV2(institutionId, userId)).thenReturn(List.of(partyProduct.getId(), partyProduct2.getId()));
+        List<Product> expectation = institutionService.getInstitutionUserProductsV2(institutionId, userId);
         Assertions.assertEquals(2, expectation.size());
         Assertions.assertEquals(expectation, products);
         Mockito.verify(msCoreConnectorMock, Mockito.times(1)).getInstitutionUserProductsV2(institutionId, userId);

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/InstitutionV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/InstitutionV2Controller.java
@@ -23,6 +23,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
@@ -100,10 +102,12 @@ public class InstitutionV2Controller {
     @GetMapping(value = "/{institutionId}/products")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.external_api.institutions.api.getInstitutionUserProducts}")
-    public List<ProductResource> getInstitutionUserProducts(@ApiParam("${swagger.external_api.institutions.model.id}")
-                                                            @PathVariable("institutionId") String institutionId) {
+    public List<ProductResource> getInstitutionProducts(@ApiParam("${swagger.external_api.institutions.model.id}")
+                                                            @PathVariable("institutionId") String institutionId,
+                                                          @ApiParam("${swagger.external_api.user.model.id}")
+                                                          @RequestParam(value = "userId") String userId) {
         log.trace("getInstitutionUserProducts start");
-        List<ProductResource> productResources = institutionService.getInstitutionUserProductsV2(institutionId)
+        List<ProductResource> productResources = institutionService.getInstitutionUserProductsV2(institutionId, userId)
                 .stream()
                 .map(productsMapper::toResource)
                 .toList();

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/InstitutionControllerV2Test.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/InstitutionControllerV2Test.java
@@ -218,7 +218,7 @@ public class InstitutionControllerV2Test extends BaseControllerTest{
         ClassPathResource outputResource = new ClassPathResource("expectations/ProductResources.json");
         String expectedResource = StringUtils.deleteWhitespace(new String(Files.readAllBytes(outputResource.getFile().toPath())));
 
-        when(institutionService.getInstitutionUserProductsV2(anyString())).thenReturn(products);
+        when(institutionService.getInstitutionUserProductsV2(anyString(), anyString())).thenReturn(products);
 
         mockMvc.perform(get("/v2/institutions/{institutionId}/products", "testInstitutionId")
                 .contentType(APPLICATION_JSON_VALUE).accept(APPLICATION_JSON_VALUE))
@@ -232,9 +232,11 @@ public class InstitutionControllerV2Test extends BaseControllerTest{
     @Test
     public void getInstitutionUserProductsWithEmptyList() throws Exception {
 
-        when(institutionService.getInstitutionUserProductsV2("testInstitutionId")).thenReturn(Collections.emptyList());
+
+        when(institutionService.getInstitutionUserProductsV2("testInstitutionId", "testUserId")).thenReturn(Collections.emptyList());
 
         mockMvc.perform(get("/v2/institutions/{institutionId}/products", "testInstitutionId")
+                        .param("userId", "testUserId")
                 .contentType(APPLICATION_JSON_VALUE).accept(APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$", hasSize(0)))
                 .andExpect(status().isOk())

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/InstitutionControllerV2Test.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/InstitutionControllerV2Test.java
@@ -221,6 +221,7 @@ public class InstitutionControllerV2Test extends BaseControllerTest{
         when(institutionService.getInstitutionUserProductsV2(anyString(), anyString())).thenReturn(products);
 
         mockMvc.perform(get("/v2/institutions/{institutionId}/products", "testInstitutionId")
+                        .param("userId", "testUserId")
                 .contentType(APPLICATION_JSON_VALUE).accept(APPLICATION_JSON_VALUE))
                 .andExpect(content().string(expectedResource))
                 .andExpect(jsonPath("$", hasSize(2)))


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Modified the controller handling the /institutions/{institutionId}/products endpoint to accept the userId as a query parameter.
* Updated the logic to use the userId from the request parameter instead of extracting it from the JWT token.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR adds a userId request parameter to the /institutions/{institutionId}/products endpoint. This change allows the userId to be passed directly in the request rather than being retrieved from the JWT token.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.