### PR TITLE
[SELC-5021] Fix: Change AddInstitution API to invoke _createPgInstitutionUsingPOST of ms-core

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/api/MsCoreConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/api/MsCoreConnector.java
@@ -26,4 +26,7 @@ public interface MsCoreConnector {
     Collection<Institution> getInstitutionsByGeoTaxonomies(String geoTaxIds, SearchMode searchMode);
 
     List<String> getInstitutionUserProductsV2(String institutionId, String id);
+
+    String createPgInstitution(String description, String taxId);
+
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/api/MsCoreConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/api/MsCoreConnector.java
@@ -5,14 +5,11 @@ import it.pagopa.selfcare.external_api.model.institutions.Institution;
 import it.pagopa.selfcare.external_api.model.institutions.SearchMode;
 import it.pagopa.selfcare.external_api.model.onboarding.InstitutionOnboarding;
 import it.pagopa.selfcare.external_api.model.onboarding.OnboardedInstitutionInfo;
-import it.pagopa.selfcare.external_api.model.pnpg.CreatePnPgInstitution;
 
 import java.util.Collection;
 import java.util.List;
 
 public interface MsCoreConnector {
-
-    String createPnPgInstitution(CreatePnPgInstitution request);
 
 
     InstitutionOnboarding getInstitutionOnboardings(String institutionId, String productId);

--- a/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/MsCoreConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/MsCoreConnectorImpl.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.external_api.connector.rest;
 
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
+import it.pagopa.selfcare.core.generated.openapi.v1.dto.CreatePgInstitutionRequest;
 import it.pagopa.selfcare.core.generated.openapi.v1.dto.InstitutionResponse;
 import it.pagopa.selfcare.core.generated.openapi.v1.dto.OnboardingResponse;
 import it.pagopa.selfcare.external_api.api.MsCoreConnector;
@@ -151,5 +152,19 @@ public class MsCoreConnectorImpl implements MsCoreConnector {
             }).toList();
         }
         return Collections.emptyList();
+    }
+
+    @Override
+    public String createPgInstitution(String description, String taxId) {
+        log.trace("createPgInstitution start");
+        log.debug("createPgInstitution description = {},  taxId = {}", description, taxId);
+        CreatePgInstitutionRequest createPgInstitutionRequest = new CreatePgInstitutionRequest(description, false, taxId);
+        InstitutionResponse institutionResponse = Objects.requireNonNull(institutionApiClient.
+                _createPgInstitutionUsingPOST(createPgInstitutionRequest)
+                .getBody());
+
+        log.trace("createPgInstitution end");
+
+        return institutionResponse.getId();
     }
 }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/MsCoreConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/MsCoreConnectorImpl.java
@@ -47,19 +47,6 @@ public class MsCoreConnectorImpl implements MsCoreConnector {
     protected static final String USER_ID_IS_REQUIRED = "A userId is required";
     protected static final String REQUIRED_INSTITUTION_ID_MESSAGE = "An Institution external id is required";
 
-
-
-    @Override
-    public String createPnPgInstitution(CreatePnPgInstitution request) {
-        log.trace("createPnPgInstitution start");
-        log.debug(LogUtils.CONFIDENTIAL_MARKER, "createPnPgInstitution request = {}", request);
-        CreatePnPgInstitutionRequest institutionRequest = new CreatePnPgInstitutionRequest(request);
-        InstitutionPnPgResponse pnPgInstitution = restClient.createPnPgInstitution(institutionRequest);
-        log.debug("createPnPgInstitution result = {}", pnPgInstitution.getId());
-        log.trace("createPnPgInstitution end");
-        return pnPgInstitution.getId();
-    }
-
     @Override
     public InstitutionOnboarding getInstitutionOnboardings(String institutionId, String productId) {
         log.trace("getInstitutionOnboardings start");

--- a/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/MsCoreConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/MsCoreConnectorImpl.java
@@ -144,7 +144,6 @@ public class MsCoreConnectorImpl implements MsCoreConnector {
     @Override
     public String createPgInstitution(String description, String taxId) {
         log.trace("createPgInstitution start");
-        log.debug("createPgInstitution description = {},  taxId = {}", description, taxId);
         CreatePgInstitutionRequest createPgInstitutionRequest = new CreatePgInstitutionRequest(description, false, taxId);
         InstitutionResponse institutionResponse = Objects.requireNonNull(institutionApiClient.
                 _createPgInstitutionUsingPOST(createPgInstitutionRequest)

--- a/connector/rest/src/test/java/it/pagopa/selfcare/external_api/connector/rest/MsCoreConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/external_api/connector/rest/MsCoreConnectorImplTest.java
@@ -34,10 +34,7 @@ import org.springframework.http.ResponseEntity;
 import javax.validation.ValidationException;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static it.pagopa.selfcare.commons.utils.TestUtils.mockInstance;
 import static it.pagopa.selfcare.external_api.model.user.RelationshipState.ACTIVE;
@@ -326,6 +323,20 @@ class MsCoreConnectorImplTest extends BaseConnectorTest {
         assertEquals(1, onboardedInstitutionInfos.size());
         assertEquals(expectation, onboardedInstitutionInfos);
         verify(institutionApiClient, times(1))._retrieveInstitutionByIdUsingGET(institutionId);
+
+    }
+
+    @Test
+    void createPgInstitution() {
+        String institutionId = UUID.randomUUID().toString();
+        //given
+        InstitutionResponse response = new InstitutionResponse();
+        response.setId(institutionId);
+        when(institutionApiClient._createPgInstitutionUsingPOST(any())).thenReturn(ResponseEntity.of(Optional.of(response)));
+        //when
+        String institutionPnPgResponse = msCoreConnector.createPgInstitution("description",  "taxId");
+        //then
+        assertEquals(institutionId, institutionPnPgResponse);
 
     }
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/external_api/connector/rest/MsCoreConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/external_api/connector/rest/MsCoreConnectorImplTest.java
@@ -10,20 +10,16 @@ import it.pagopa.selfcare.external_api.connector.rest.client.MsUserApiRestClient
 import it.pagopa.selfcare.external_api.connector.rest.config.BaseConnectorTest;
 import it.pagopa.selfcare.external_api.connector.rest.mapper.InstitutionMapperImpl;
 import it.pagopa.selfcare.external_api.connector.rest.model.institution.Institutions;
-import it.pagopa.selfcare.external_api.connector.rest.model.pnpg.CreatePnPgInstitutionRequest;
-import it.pagopa.selfcare.external_api.connector.rest.model.pnpg.InstitutionPnPgResponse;
 import it.pagopa.selfcare.external_api.exceptions.ResourceNotFoundException;
 import it.pagopa.selfcare.external_api.model.institutions.GeographicTaxonomy;
 import it.pagopa.selfcare.external_api.model.institutions.Institution;
 import it.pagopa.selfcare.external_api.model.institutions.SearchMode;
 import it.pagopa.selfcare.external_api.model.onboarding.InstitutionOnboarding;
 import it.pagopa.selfcare.external_api.model.onboarding.OnboardedInstitutionInfo;
-import it.pagopa.selfcare.external_api.model.pnpg.CreatePnPgInstitution;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.UserDataResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -36,7 +32,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
 
-import static it.pagopa.selfcare.commons.utils.TestUtils.mockInstance;
 import static it.pagopa.selfcare.external_api.model.user.RelationshipState.ACTIVE;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -59,27 +54,6 @@ class MsCoreConnectorImplTest extends BaseConnectorTest {
 
     @Spy
     InstitutionMapperImpl institutionMapper;
-
-    @Test
-    void createPnPgInstitutionOK() {
-        //given
-        CreatePnPgInstitution request = mockInstance(new CreatePnPgInstitution());
-        InstitutionPnPgResponse institutionPnPgResponse = mockInstance(new InstitutionPnPgResponse());
-        when(msCoreRestClient.createPnPgInstitution(any()))
-                .thenReturn(institutionPnPgResponse);
-        //when
-        String response = msCoreConnector.createPnPgInstitution(request);
-        //then
-        ArgumentCaptor<CreatePnPgInstitutionRequest> requestCaptor = ArgumentCaptor.forClass(CreatePnPgInstitutionRequest.class);
-        verify(msCoreRestClient, times(1))
-                .createPnPgInstitution(requestCaptor.capture());
-        verifyNoMoreInteractions(msCoreRestClient);
-        CreatePnPgInstitutionRequest capturedRequest = requestCaptor.getValue();
-        assertEquals(request.getExternalId(), capturedRequest.getTaxId());
-        assertEquals(request.getDescription(), capturedRequest.getDescription());
-        assertEquals(institutionPnPgResponse.getId(), response);
-
-    }
 
 
     @Test

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImpl.java
@@ -187,12 +187,7 @@ class InstitutionServiceImpl implements InstitutionService {
     public String addInstitution(CreatePnPgInstitution request) {
         log.trace("addInstitution start");
         log.debug("addInstitution request = {}", request);
-        String institutionInternalId;
-        try {
-            institutionInternalId = msCoreConnector.getInstitutionByExternalId(request.getExternalId()).getId();
-        } catch (ResourceNotFoundException e) {
-            institutionInternalId = msCoreConnector.createPnPgInstitution(request);
-        }
+        String institutionInternalId = msCoreConnector.createPgInstitution(request.getDescription(), request.getExternalId());
         log.debug("addInstitution result = {}", institutionInternalId);
         log.trace("addInstitution end");
         return institutionInternalId;

--- a/core/src/test/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImplTest.java
@@ -2,9 +2,7 @@ package it.pagopa.selfcare.external_api.core;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
-import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.external_api.api.*;
-import it.pagopa.selfcare.external_api.exceptions.ResourceNotFoundException;
 import it.pagopa.selfcare.external_api.model.institutions.GeographicTaxonomy;
 import it.pagopa.selfcare.external_api.model.institutions.Institution;
 import it.pagopa.selfcare.external_api.model.institutions.SearchMode;
@@ -25,8 +23,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.security.authentication.TestingAuthenticationToken;
-import org.springframework.security.test.context.TestSecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -312,12 +308,5 @@ class InstitutionServiceImplTest extends BaseServiceTestUtils {
         assertNotNull(result);
         verify(registryProxyConnector, times(1)).verifyLegal(taxId, vatNumber);
 
-    }
-
-    private Product createDummyProduct(int bias){
-        Product product = new Product();
-        product.setId("id"+bias);
-        product.setTitle("title"+bias);
-        return product;
     }
 }

--- a/core/src/test/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/external_api/core/InstitutionServiceImplTest.java
@@ -288,29 +288,14 @@ class InstitutionServiceImplTest extends BaseServiceTestUtils {
     }
 
     @Test
-    void addInstitutionExists() {
+    void addInstitution() {
         CreatePnPgInstitution createPnPgInstitution = new CreatePnPgInstitution();
-        createPnPgInstitution.setExternalId("externalId");
-        Institution institution = new Institution();
-        institution.setId("externalId");
-        when(msCoreConnectorMock.getInstitutionByExternalId(createPnPgInstitution.getExternalId())).thenReturn(institution);
+        createPnPgInstitution.setDescription("description");
+        createPnPgInstitution.setExternalId("taxId");
+        String institutionId = UUID.randomUUID().toString();
+        when(msCoreConnectorMock.createPgInstitution("description", "taxId")).thenReturn(institutionId);
         String expectation = institutionService.addInstitution(createPnPgInstitution);
-        Assertions.assertEquals(institution.getId(), expectation);
-        Mockito.verify(msCoreConnectorMock, Mockito.times(1)).getInstitutionByExternalId(createPnPgInstitution.getExternalId());
-        Mockito.verifyNoMoreInteractions(msCoreConnectorMock);
-    }
-
-    @Test
-    void addInstitutionNotExists() {
-        CreatePnPgInstitution createPnPgInstitution = new CreatePnPgInstitution();
-        createPnPgInstitution.setExternalId("externalId");
-        Institution institution = new Institution();
-        institution.setId("internalId");
-        when(msCoreConnectorMock.getInstitutionByExternalId(createPnPgInstitution.getExternalId())).thenThrow(ResourceNotFoundException.class);
-        when(msCoreConnectorMock.createPnPgInstitution(createPnPgInstitution)).thenReturn(institution.getId());
-        String expectation = institutionService.addInstitution(createPnPgInstitution);
-        Assertions.assertEquals(institution.getId(), expectation);
-        Mockito.verify(msCoreConnectorMock, Mockito.times(1)).createPnPgInstitution(createPnPgInstitution);
+        Assertions.assertEquals(institutionId, expectation);
     }
 
     @Test


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Changed AddInstitution API to invoke _createPgInstitutionUsingPOST of ms-core

<!--- Describe your changes in detail -->

#### Motivation and Context
To prevent errors in the event of parallel institution creation requests, it is necessary to modify the flow in order to call a single API that retrieves or saves the institution via the taxCode
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.