### PR TITLE
[SELC-5050] feat: Addition of GET /users Endpoint

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1168,7 +1168,7 @@
     },
     "/v1/tokens/products/{productId}" : {
       "get" : {
-        "tags" : [ "external-v2" ],
+        "tags" : [ "Token", "external-v2" ],
         "summary" : "Service to retrieve tokens from product's identifier",
         "description" : "Service to retrieve tokens from product's identifier",
         "operationId" : "getTokensFromProductUsingGET",
@@ -1260,8 +1260,152 @@
       }
     },
     "/v2/users" : {
+      "get" : {
+        "tags" : [ "User", "external-v2" ],
+        "summary" : "getUserInstitution",
+        "description" : "The API retrieves paged users with optional filters in input as query params",
+        "operationId" : "v2getUserInstitution",
+        "parameters" : [ {
+          "name" : "institutionId",
+          "in" : "query",
+          "description" : "institutionId",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "userId",
+          "in" : "query",
+          "description" : "userId",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "roles",
+          "in" : "query",
+          "description" : "roles",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "DELEGATE", "MANAGER", "OPERATOR", "SUB_DELEGATE" ]
+          }
+        }, {
+          "name" : "states",
+          "in" : "query",
+          "description" : "states",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "products",
+          "in" : "query",
+          "description" : "products",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "productRoles",
+          "in" : "query",
+          "description" : "productRoles",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "page",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "size",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/UserInstitutionResource"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      },
       "post" : {
-        "tags" : [ "external-v2", "support" ],
+        "tags" : [ "User", "external-v2", "support" ],
         "summary" : "getUserInfo",
         "description" : "Service to retrieve user info including institutions and products linked to him, this service retrives 100 institutions at most",
         "operationId" : "V2getUserInfoUsingGET",
@@ -2774,6 +2918,68 @@
           "user" : {
             "description" : "Object that includes all info about a user",
             "$ref" : "#/components/schemas/UserResource"
+          }
+        }
+      },
+      "UserInstitutionResource" : {
+        "title" : "UserInstitutionResource",
+        "required" : [ "userId" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "institutionDescription" : {
+            "type" : "string",
+            "description" : "Institution's description"
+          },
+          "institutionId" : {
+            "type" : "string",
+            "description" : "Institution's Id"
+          },
+          "institutionRootName" : {
+            "type" : "string"
+          },
+          "products" : {
+            "type" : "array",
+            "description" : "Object that includes all info about onboarded institutions linked to a user",
+            "items" : {
+              "$ref" : "#/components/schemas/UserProductResource"
+            }
+          },
+          "userId" : {
+            "type" : "string",
+            "description" : "User's unique identifier"
+          }
+        }
+      },
+      "UserProductResource" : {
+        "title" : "UserProductResource",
+        "type" : "object",
+        "properties" : {
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "productId" : {
+            "type" : "string"
+          },
+          "productRole" : {
+            "type" : "string"
+          },
+          "role" : {
+            "type" : "string",
+            "description" : "Available values: MANAGER, DELEGATE, SUB_DELEGATE, OPERATOR, ADMIN_EA"
+          },
+          "status" : {
+            "type" : "string"
+          },
+          "tokenId" : {
+            "type" : "string"
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
           }
         }
       },

--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/api/UserMsConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/api/UserMsConnector.java
@@ -1,10 +1,10 @@
 package it.pagopa.selfcare.external_api.api;
 
-import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.external_api.model.institutions.Institution;
 import it.pagopa.selfcare.external_api.model.user.User;
 import it.pagopa.selfcare.external_api.model.user.UserInstitution;
 import it.pagopa.selfcare.external_api.model.user.UserToOnboard;
+import it.pagopa.selfcare.onboarding.common.PartyRole;
 
 import java.util.List;
 

--- a/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/user/UserInstitution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_api/model/user/UserInstitution.java
@@ -7,8 +7,11 @@ import java.util.List;
 
 @Data
 public class UserInstitution {
-    private String institutionId;
 
+    private String id;
+    private String institutionId;
+    private String institutionDescription;
+    private String institutionRootName;
     private String userId;
     private String userMailUuid;
 

--- a/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/UserMsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/UserMsConnectorImpl.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.external_api.connector.rest;
 
+import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.external_api.api.UserMsConnector;
 import it.pagopa.selfcare.external_api.connector.rest.client.MsUserApiRestClient;
 import it.pagopa.selfcare.external_api.connector.rest.mapper.UserMapper;
@@ -48,7 +49,7 @@ public class UserMsConnectorImpl implements UserMsConnector {
         return userMapper.toUserFromUserDetailResponse(msUserApiRestClient._usersSearchPost(null, searchUserDto).getBody());
     }
 
-    private List<it.pagopa.selfcare.user.generated.openapi.v1.dto.PartyRole> toDtoPartyRole(List<it.pagopa.selfcare.commons.base.security.PartyRole> roles) {
+    private List<it.pagopa.selfcare.user.generated.openapi.v1.dto.PartyRole> toDtoPartyRole(List<PartyRole> roles) {
         List<it.pagopa.selfcare.user.generated.openapi.v1.dto.PartyRole> partyRoles = new ArrayList<>();
         if (roles != null) {
             roles.forEach(partyRole -> {
@@ -66,7 +67,7 @@ public class UserMsConnectorImpl implements UserMsConnector {
 
         Product1 product = Product1.builder()
                 .productId(productId)
-                .role(PartyRole.valueOf(role))
+                .role(it.pagopa.selfcare.user.generated.openapi.v1.dto.PartyRole.valueOf(role))
                 .productRoles(productRoles)
                 .build();
 
@@ -88,7 +89,7 @@ public class UserMsConnectorImpl implements UserMsConnector {
     public String addUserRole(String userId, Institution institution, String productId, String role, List<String> productRoles) {
         it.pagopa.selfcare.user.generated.openapi.v1.dto.Product product = it.pagopa.selfcare.user.generated.openapi.v1.dto.Product.builder()
                 .productId(productId)
-                .role(PartyRole.valueOf(role))
+                .role(it.pagopa.selfcare.user.generated.openapi.v1.dto.PartyRole.valueOf(role))
                 .productRoles(productRoles)
                 .build();
 

--- a/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/UserMsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/external_api/connector/rest/UserMsConnectorImpl.java
@@ -35,7 +35,7 @@ public class UserMsConnectorImpl implements UserMsConnector {
     }
 
     @Override
-    public List<UserInstitution> getUsersInstitutions(String userId, String institutionId, Integer page, Integer size, List<String> productRoles, List<String> products, List<it.pagopa.selfcare.commons.base.security.PartyRole> roles, List<String> states) {
+    public List<UserInstitution> getUsersInstitutions(String userId, String institutionId, Integer page, Integer size, List<String> productRoles, List<String> products, List<PartyRole> roles, List<String> states) {
 
         return Objects.requireNonNull(msUserApiRestClient._usersGet(
                         institutionId, page, productRoles, products, toDtoPartyRole(roles)

--- a/connector/rest/src/test/java/it/pagopa/selfcare/external_api/connector/rest/UserMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/external_api/connector/rest/UserMsConnectorImplTest.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.external_api.connector.rest;
 
+import it.pagopa.selfcare.onboarding.common.PartyRole;
 import com.fasterxml.jackson.core.type.TypeReference;
-import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.external_api.connector.rest.client.MsUserApiRestClient;
 import it.pagopa.selfcare.external_api.connector.rest.config.BaseConnectorTest;
 import it.pagopa.selfcare.external_api.connector.rest.mapper.UserMapperImpl;

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/UserService.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/UserService.java
@@ -4,6 +4,8 @@ import it.pagopa.selfcare.external_api.model.onboarding.OnboardedInstitutionInfo
 import it.pagopa.selfcare.external_api.model.user.RelationshipState;
 import it.pagopa.selfcare.external_api.model.user.UserDetailsWrapper;
 import it.pagopa.selfcare.external_api.model.user.UserInfoWrapper;
+import it.pagopa.selfcare.external_api.model.user.UserInstitution;
+import it.pagopa.selfcare.onboarding.common.PartyRole;
 
 import java.util.List;
 
@@ -17,4 +19,6 @@ public interface UserService {
     UserDetailsWrapper getUserOnboardedProductsDetailsV2(String userId, String institutionId, String productId);
 
     List<OnboardedInstitutionInfo> getOnboardedInstitutionsDetailsActive(String userId, String productId);
+
+    List<UserInstitution> getUsersInstitutions(String userId, String institutionId, Integer page, Integer size, List<String> productRoles, List<String> products, List<PartyRole> roles, List<String> states);
 }

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/UserServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/UserServiceImpl.java
@@ -169,4 +169,9 @@ public class UserServiceImpl implements UserService {
 
         return onboardedInstitutionsInfo;
     }
+
+    @Override
+    public List<UserInstitution> getUsersInstitutions(String userId, String institutionId, Integer page, Integer size, List<String> productRoles, List<String> products, List<PartyRole> roles, List<String> states){
+        return userMsConnector.getUsersInstitutions(userId,institutionId, page, size, productRoles, products, roles, states);
+    }
 }

--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/UserServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/UserServiceImpl.java
@@ -1,12 +1,12 @@
 package it.pagopa.selfcare.external_api.core;
 
-import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.external_api.api.MsCoreConnector;
 import it.pagopa.selfcare.external_api.api.UserMsConnector;
 import it.pagopa.selfcare.external_api.model.onboarding.OnboardedInstitutionInfo;
 import it.pagopa.selfcare.external_api.model.onboarding.OnboardedInstitutionResponse;
 import it.pagopa.selfcare.external_api.model.onboarding.mapper.OnboardingInstitutionMapper;
 import it.pagopa.selfcare.external_api.model.user.*;
+import it.pagopa.selfcare.onboarding.common.PartyRole;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -77,7 +77,7 @@ public class UserServiceImpl implements UserService {
         if (!onboardedProductResponses.isEmpty()) {
             onboardedProductResponses.forEach(onboardedProductResponse -> roles.add(onboardedProductResponse.getProductRole()));
             productDetails = new ProductDetails();
-            productDetails.setRole(PartyRole.valueOf(onboardedProductResponses.get(0).getRole()));
+            productDetails.setRole(it.pagopa.selfcare.commons.base.security.PartyRole.valueOf(onboardedProductResponses.get(0).getRole()));
             productDetails.setProductId(productId);
             productDetails.setRoles(roles);
             if(onboardedProductResponses.get(0).getCreatedAt() != null) {

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/TokenController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/TokenController.java
@@ -51,6 +51,7 @@ public class TokenController {
      * * Code: 404, Message: product not found
      */
     @Tag(name = "external-v2")
+    @Tag(name = "Token")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.external_api.api.tokens.findFromProduct}", notes = "${swagger.external_api.api.tokens.findFromProduct}", nickname = "getTokensFromProductUsingGET")
     @GetMapping(value = "/products/{productId}")

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/model/mapper/UserInfoResourceMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/model/mapper/UserInfoResourceMapper.java
@@ -3,9 +3,11 @@ package it.pagopa.selfcare.external_api.web.model.mapper;
 import it.pagopa.selfcare.external_api.model.user.ProductDetails;
 import it.pagopa.selfcare.external_api.model.user.UserDetailsWrapper;
 import it.pagopa.selfcare.external_api.model.user.UserInfoWrapper;
+import it.pagopa.selfcare.external_api.model.user.UserInstitution;
 import it.pagopa.selfcare.external_api.web.model.onboarding.OnboardedProductResource;
 import it.pagopa.selfcare.external_api.web.model.user.UserDetailsResource;
 import it.pagopa.selfcare.external_api.web.model.user.UserInfoResource;
+import it.pagopa.selfcare.external_api.web.model.user.UserInstitutionResource;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -24,4 +26,6 @@ public interface UserInfoResourceMapper {
 
     @Named("toOnboardedProductResource")
     OnboardedProductResource toOnboardedProductResource(ProductDetails productDetails);
+
+    UserInstitutionResource toUserInstitutionResource(UserInstitution entity);
 }

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/model/user/UserInstitutionResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/model/user/UserInstitutionResource.java
@@ -1,0 +1,42 @@
+package it.pagopa.selfcare.external_api.web.model.user;
+
+import io.swagger.annotations.ApiModelProperty;
+import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.external_api.model.onboarding.ProductInfo;
+import it.pagopa.selfcare.external_api.model.user.OnboardedProductResponse;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+;
+
+@Data
+public class UserInstitutionResource {
+
+    private String id;
+
+    @ApiModelProperty(value = "${swagger.external_api.user.model.id}", required = true)
+    private String userId;
+    @ApiModelProperty(value = "${swagger.external_api.user.model.onboardedInstitutions.id}")
+    private String institutionId;
+    @ApiModelProperty(value = "${swagger.external_api.user.model.onboardedInstitutions.description}")
+    private String institutionDescription;
+    private String institutionRootName;
+    @ApiModelProperty(value = "${swagger.external_api.userInfo.model.onboardedInstitutions}")
+    private List<UserProductResource> products;
+
+    @Data
+    public static class UserProductResource {
+        private String productId;
+        private String tokenId;
+        private String status;
+        private String productRole;
+        @ApiModelProperty(value = "Available values: MANAGER, DELEGATE, SUB_DELEGATE, OPERATOR, ADMIN_EA")
+        private String role;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+    }
+
+}

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/UserControllerV2Test.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/UserControllerV2Test.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -187,6 +187,29 @@ class UserControllerV2Test extends BaseControllerTest{
         product.setRole(PartyRole.MANAGER);
         product.setCreatedAt(OffsetDateTime.parse("2024-04-17T01:00:00+01:00"));
         return product;
+    }
+
+
+
+    @Test
+    void getUserInstitution() throws Exception {
+
+        final String userId = "userId";
+        final String institutionId = "institutionId";
+        final String productId = "productId";
+
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get(BASE_URL)
+                        .queryParam("userId", userId)
+                        .queryParam("institutionId", "institutionId")
+                        .queryParam("products", productId)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(userService, times(1))
+                .getUsersInstitutions(userId, institutionId, 0, 100, null, List.of(productId), null, null);
     }
 
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Added a new GET /users endpoint to our service.
* The endpoint fetches user data from the ms-user microservice.
* Filtered out the userMailUuid attribute from the response to ensure it is not exposed externally.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request introduces a new endpoint **GET /users** in our service, which mirrors the existing endpoint on the ms-user microservice. The primary purpose of this addition is to prevent the exposure of the _userMailUuid_ attribute, which is not significant or necessary for external use in the Selfcare product.



#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.