### PR TITLE
[SELC-5086] Fix: refactor getOnboardedInstitutionsDetails API to call user-ms api with 350 as pagesize

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/external_api/core/UserServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/external_api/core/UserServiceImpl.java
@@ -94,7 +94,8 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public List<OnboardedInstitutionInfo> getOnboardedInstitutionsDetails(String userId, String productId) {
-        List<UserInstitution> usersInstitutions = userMsConnector.getUsersInstitutions(userId, null, null, null, null, Objects.isNull(productId) ? null : List.of(productId), null, null);
+        //fix temporanea per il funzionamento della getUserInfo di support
+        List<UserInstitution> usersInstitutions = userMsConnector.getUsersInstitutions(userId, null, null, 350, null, Objects.isNull(productId) ? null : List.of(productId), null, null);
         List<OnboardedInstitutionInfo> onboardedInstitutionsInfo = new ArrayList<>();
 
         usersInstitutions.forEach(userInstitution -> {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- refactor getOnboardedInstitutionsDetails API to call user-ms api with 350 as pagesize (temporary fix)
<!--- Describe your changes in detail -->

#### Motivation and Context
we need to set pageSize in user-ms api call instead of use default (100) because some users have more than 100 items
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.