### PR TITLE
feat: Set bearerAuth global when SecurityScheme is empty

### DIFF
--- a/infra/apim_v2/api/ms_external_api/v2/openapi_merge/openapi_merge.json
+++ b/infra/apim_v2/api/ms_external_api/v2/openapi_merge/openapi_merge.json
@@ -13,7 +13,7 @@
           }
         },
       {
-        "inputFile": "../../../../../../../docs/pagopa/selfcare-ms-core/openapi.json",
+        "inputFile": "../../../../../../../docs/pagopa/selfcare-institution-ms/openapi.json",
         "operationSelection": {
           "includeTags": ["external-v2"]
         }

--- a/infra/apim_v2/api/ms_internal_api/v1/openapi_merge/openapi_merge.json
+++ b/infra/apim_v2/api/ms_internal_api/v1/openapi_merge/openapi_merge.json
@@ -13,7 +13,7 @@
           }
         },
       {
-        "inputFile": "../../../../../../../docs/pagopa/selfcare-ms-core/openapi.json",
+        "inputFile": "../../../../../../../docs/pagopa/selfcare-institution-ms/openapi.json",
         "operationSelection": {
           "includeTags": ["internal-v1"]
         }

--- a/infra/apim_v2/api/selfcare_support_service/v1/openapi_merge/openapi_merge.json
+++ b/infra/apim_v2/api/selfcare_support_service/v1/openapi_merge/openapi_merge.json
@@ -13,7 +13,7 @@
           }
         },
       {
-        "inputFile": "../../../../../../../docs/pagopa/selfcare-ms-core/openapi.json",
+        "inputFile": "../../../../../../../docs/pagopa/selfcare-institution-ms/openapi.json",
         "operationSelection": {
           "includeTags": ["support"]
         }

--- a/infra/apim_v2/api_pnpg/external_api_for_pnpg/v2/openapi_merge/openapi_merge.json
+++ b/infra/apim_v2/api_pnpg/external_api_for_pnpg/v2/openapi_merge/openapi_merge.json
@@ -13,7 +13,7 @@
           }
         },
       {
-        "inputFile": "../../../../../../../docs/pagopa/selfcare-ms-core/openapi.json",
+        "inputFile": "../../../../../../../docs/pagopa/selfcare-institution-ms/openapi.json",
         "operationSelection": {
           "includeTags": ["external-pnpg"]
         }

--- a/infra/apim_v2/api_pnpg/pnpg_support_service/v1/openapi_merge/openapi_merge.json
+++ b/infra/apim_v2/api_pnpg/pnpg_support_service/v1/openapi_merge/openapi_merge.json
@@ -13,7 +13,7 @@
           }
         },
       {
-        "inputFile": "../../../../../../../docs/pagopa/selfcare-ms-core/openapi.json",
+        "inputFile": "../../../../../../../docs/pagopa/selfcare-institution-ms/openapi.json",
         "operationSelection": {
           "includeTags": ["support-pnpg"]
         }

--- a/infra/apim_v2/openapi_merge/remove_v_and_tags.js
+++ b/infra/apim_v2/openapi_merge/remove_v_and_tags.js
@@ -53,6 +53,25 @@ fs.readFile(inputFilePathComplete, 'utf8', (err, data) => {
         });
     }
 
+
+    // Set security bearerAuth
+    if (openapi.paths && typeof openapi.paths === 'object') {
+        Object.keys(openapi.paths).forEach(path => {
+            const pathItem = openapi.paths[path];
+            ['get', 'post', 'put', 'delete', 'options', 'head', 'patch', 'trace'].forEach(method => {
+                if (pathItem[method] && pathItem[method].security) {
+                    pathItem[method].security.forEach(schema => {
+                        if(schema["SecurityScheme"]) {
+                            delete schema["SecurityScheme"];
+                            schema["bearerAuth"] = ["global"]
+                        }
+                    })
+                }
+            });
+           
+        });
+    }
+
     // Filtra i tag nei paths
     if (openapi.paths && typeof openapi.paths === 'object') {
         Object.keys(openapi.paths).forEach(path => {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
This pull request introduces a modification to handle an issue when merging with OpenAPI specifications generated via Quarkus happens. Specifically, the generated OpenAPI includes an empty security schema, which needs to be replaced with a bearerAuth global.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This update addresses an issue where the OpenAPI specification generated by Quarkus includes an empty SecurityScheme, which is not valid for API security. By replacing this with a bearerAuth scheme, the OpenAPI spec will correctly define security requirements for the endpoints.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.