### PR TITLE
fix: reference pnpg certificate on external-data vault API

### DIFF
--- a/infra/apim_v2/api_pnpg/jwt_base_policy.xml.tpl
+++ b/infra/apim_v2/api_pnpg/jwt_base_policy.xml.tpl
@@ -1,0 +1,49 @@
+<policies>
+    <inbound>
+        <base />
+        <set-variable name="jwt" value="@{
+                // 1) Construct the Base64Url-encoded header
+                var header = new { typ = "JWT", alg = "RS256", kid = "${KID}" };
+                var jwtHeaderBase64UrlEncoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(header))).Replace("/", "_").Replace("+", "-"). Replace("=", "");
+                // As the header is a constant, you may use this equivalent Base64Url-encoded string instead to save the repetitive computation above.
+                // var jwtHeaderBase64UrlEncoded = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9";
+
+                // 2) Construct the Base64Url-encoded payload
+                var iat = new DateTimeOffset(DateTime.Now).ToUnixTimeSeconds();  // sets the expiration of the token to be 30 seconds from now
+                var exp = new DateTimeOffset(DateTime.Now.AddMinutes(30)).ToUnixTimeSeconds();  // sets the expiration of the token to be 30 seconds from now
+                var uid = "pnpg";
+                var aud = "${API_DOMAIN}";
+                var iss = "SPID";
+                var name = "apim";
+                var payload = new { name, exp, uid, aud, iss , iat};
+                var jwtPayloadBase64UrlEncoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(payload))).Replace("/", "_").Replace("+", "-"). Replace("=", "");
+
+                // 3) Construct the Base64Url-encoded signature
+                using (RSA rsa = context.Deployment.Certificates["${JWT_CERTIFICATE_THUMBPRINT}"].GetRSAPrivateKey())
+                {
+                byte[] data2sign = Encoding.UTF8.GetBytes($"{jwtHeaderBase64UrlEncoded}.{jwtPayloadBase64UrlEncoded}");
+                var signature = rsa.SignData(data2sign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);;
+                var jwtSignatureBase64UrlEncoded = Convert.ToBase64String(signature).Replace("/", "_").Replace("+", "-"). Replace("=", "");
+
+                // 4) Return the HMAC SHA256-signed JWT as the value for the Authorization header
+                return $"Bearer {jwtHeaderBase64UrlEncoded}.{jwtPayloadBase64UrlEncoded}.{jwtSignatureBase64UrlEncoded}";
+                }
+
+                }"/>
+        <set-header name="X-Client-Ip" exists-action="override">
+            <value>@(context.Request.IpAddress)</value>
+        </set-header>
+        <set-header name="Authorization" exists-action="override">
+        <value>@((string)context.Variables["jwt"])</value>
+        </set-header>
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/infra/apim_v2/apim_pnpg.tf
+++ b/infra/apim_v2/apim_pnpg.tf
@@ -132,7 +132,7 @@ module "apim_pnpg_external_api_ms_v2" {
     basePath = "v1"
   })
 
-  xml_content = templatefile("./api/jwt_base_policy.xml.tpl", {
+  xml_content = templatefile("./api_pnpg/jwt_base_policy.xml.tpl", {
     API_DOMAIN                 = local.api_pnpg_domain
     KID                        = data.azurerm_key_vault_secret.jwt_kid_pnpg.value
     JWT_CERTIFICATE_THUMBPRINT = azurerm_api_management_certificate.jwt_certificate_pnpg.thumbprint
@@ -219,7 +219,7 @@ module "apim_pnpg_support_service_v2" {
     basePath = "v1"
   })
 
-  xml_content = templatefile("./api/jwt_base_policy.xml.tpl", {
+  xml_content = templatefile("./api_pnpg/jwt_base_policy.xml.tpl", {
     API_DOMAIN                 = local.api_pnpg_domain
     KID                        = data.azurerm_key_vault_secret.jwt_kid_pnpg.value
     JWT_CERTIFICATE_THUMBPRINT = azurerm_api_management_certificate.jwt_certificate_pnpg.thumbprint

--- a/infra/apim_v2/apim_pnpg.tf
+++ b/infra/apim_v2/apim_pnpg.tf
@@ -68,10 +68,10 @@ module "apim_pnpg_external_api_data_vault_v1" {
     basePath = "v1"
   })
 
-  xml_content = templatefile("./api/jwt_base_policy.xml.tpl", {
-    API_DOMAIN                 = local.api_domain
-    KID                        = data.azurerm_key_vault_secret.jwt_kid.value
-    JWT_CERTIFICATE_THUMBPRINT = azurerm_api_management_certificate.jwt_certificate.thumbprint
+  xml_content = templatefile("./api_pnpg/jwt_base_policy.xml.tpl", {
+    API_DOMAIN                 = local.api_pnpg_domain
+    KID                        = data.azurerm_key_vault_secret.jwt_kid_pnpg.value
+    JWT_CERTIFICATE_THUMBPRINT = azurerm_api_management_certificate.jwt_certificate_pnpg.thumbprint
   })
 
   subscription_required = true


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
external-data vault API was using Selc certificare instead of PNPG

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.