### PR TITLE
[SELC-5432] fix: make productId param optional and rename userId param

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -207,7 +207,7 @@
     },
     "/v2/institutions" : {
       "get" : {
-        "tags" : [ "Institution", "external-pnpg", "external-v2" ],
+        "tags" : [ "Institution", "external-pnpg" ],
         "summary" : "getInstitutions",
         "description" : "The service retrieves all the onboarded institutions related to the logged user",
         "operationId" : "getInstitutionsUsingGETDeprecated",
@@ -301,7 +301,7 @@
           "name" : "productId",
           "in" : "query",
           "description" : "Product's unique identifier",
-          "required" : true,
+          "required" : false,
           "style" : "form",
           "schema" : {
             "type" : "string"
@@ -469,13 +469,13 @@
           "name" : "productId",
           "in" : "query",
           "description" : "Product's unique identifier",
-          "required" : true,
+          "required" : false,
           "style" : "form",
           "schema" : {
             "type" : "string"
           }
         }, {
-          "name" : "userId",
+          "name" : "userIdForAuth",
           "in" : "query",
           "description" : "User's unique identifier",
           "required" : false,

--- a/infra/apim_v2/apim.tf
+++ b/infra/apim_v2/apim.tf
@@ -313,22 +313,6 @@ module "apim_external_api_ms_v2" {
       })
     },
     {
-      operation_id = "getInstitutionGeographicTaxonomiesUsingGET"
-      xml_content = templatefile("./api/base_ms_url_external_policy.xml.tpl", {
-        MS_BACKEND_URL         = "https://selc-${var.env_short}-ext-api-backend-ca.${var.ca_suffix_dns_private_name}/v1/"
-        TENANT_ID              = data.azurerm_client_config.current.tenant_id
-        EXTERNAL-OAUTH2-ISSUER = data.azurerm_key_vault_secret.external-oauth2-issuer.value
-      })
-    },
-    {
-      operation_id = "getInstitutionsByGeoTaxonomiesUsingGET"
-      xml_content = templatefile("./api/base_ms_url_external_policy.xml.tpl", {
-        MS_BACKEND_URL         = "https://selc-${var.env_short}-ext-api-backend-ca.${var.ca_suffix_dns_private_name}/v1/"
-        TENANT_ID              = data.azurerm_client_config.current.tenant_id
-        EXTERNAL-OAUTH2-ISSUER = data.azurerm_key_vault_secret.external-oauth2-issuer.value
-      })
-    },
-    {
       operation_id = "getUserGroupsUsingGET"
       xml_content = templatefile("./api/ms_external_api/v2/jwt_auth_op_policy_user_group.xml.tpl", {
         MS_BACKEND_URL         = "https://selc-${var.env_short}-user-group-ca.${var.ca_suffix_dns_private_name}/v1/"
@@ -370,7 +354,7 @@ module "apim_external_api_ms_v2" {
     },
     {
       operation_id = "getDelegationsUsingGET"
-      xml_content = templatefile("./api/base_ms_url_external_policy.xml.tpl", {
+      xml_content = templatefile("./api/base_ms_url_external_product_policy.xml.tpl", {
         MS_BACKEND_URL         = "https://selc-${var.env_short}-ms-core-ca.${var.ca_suffix_dns_private_name}/"
         TENANT_ID              = data.azurerm_client_config.current.tenant_id
         EXTERNAL-OAUTH2-ISSUER = data.azurerm_key_vault_secret.external-oauth2-issuer.value

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/InstitutionV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/InstitutionV2Controller.java
@@ -48,7 +48,6 @@ public class InstitutionV2Controller {
 
     @Tag(name = "Institution")
     @Tag(name = "external-pnpg")
-    @Tag(name = "external-v2")
     @GetMapping(value = "")
     @ResponseStatus(HttpStatus.OK)
     @Deprecated
@@ -77,7 +76,7 @@ public class InstitutionV2Controller {
     public ResponseEntity<byte[]> getContract(@ApiParam("${swagger.external_api.institutions.model.id}")
                                               @PathVariable("institutionId") String institutionId,
                                               @ApiParam("${swagger.external_api.products.model.id}")
-                                              @RequestParam(value = "productId") String productId){
+                                              @RequestParam(value = "productId", required = false) String productId){
         log.trace("getContract start");
         log.debug("getContract institutionId = {}, productId = {}", institutionId, productId);
         ResourceResponse contract = contractService.getContractV2(institutionId, productId);
@@ -120,10 +119,10 @@ public class InstitutionV2Controller {
     public List<UserResource> getInstitutionUsersByProduct(@ApiParam("${swagger.external_api.institutions.model.id}")
                                                            @PathVariable("institutionId") String institutionId,
                                                            @ApiParam("${swagger.external_api.products.model.id}")
-                                                           @RequestParam("productId")
+                                                           @RequestParam(value = "productId", required = false)
                                                            String productId,
                                                            @ApiParam("${swagger.external_api.user.model.id}")
-                                                           @RequestParam(value = "userId", required = false)
+                                                           @RequestParam(value = "userIdForAuth", required = false)
                                                            Optional<String> userId,
                                                            @ApiParam("${swagger.external_api.model.productRoles}")
                                                            @RequestParam(value = "productRoles", required = false)

--- a/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/InstitutionControllerV2Test.java
+++ b/web/src/test/java/it/pagopa/selfcare/external_api/web/controller/InstitutionControllerV2Test.java
@@ -8,8 +8,8 @@ import it.pagopa.selfcare.external_api.core.UserService;
 import it.pagopa.selfcare.external_api.model.documents.ResourceResponse;
 import it.pagopa.selfcare.external_api.model.onboarding.OnboardedInstitutionResource;
 import it.pagopa.selfcare.external_api.model.user.UserProductResponse;
-import it.pagopa.selfcare.external_api.web.model.mapper.*;
 import it.pagopa.selfcare.external_api.web.model.mapper.InstitutionResourceMapperImpl;
+import it.pagopa.selfcare.external_api.web.model.mapper.ProductsMapper;
 import it.pagopa.selfcare.external_api.web.model.mapper.ProductsMapperImpl;
 import it.pagopa.selfcare.product.entity.Product;
 import org.apache.commons.lang3.StringUtils;
@@ -204,15 +204,6 @@ class InstitutionControllerV2Test extends BaseControllerTest{
                 .andExpect(content().bytes(resourceResponse.getData()));
     }
 
-    @Test
-    void getContractOkWithoutProductId() throws Exception {
-
-        String institutionId = "institutionId";
-
-        mockMvc.perform(MockMvcRequestBuilders.get(BASE_URL + "/{institutionId}/contract", institutionId)
-                .accept(MediaType.APPLICATION_OCTET_STREAM))
-                .andExpect(status().isBadRequest());
-    }
 
     @Test
     void getInstitutionUserProductsWith2Elements() throws Exception {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- make productId param optional in getContract and getInstitutionUsersByProduct
- rename userId param to userIdForAuth in getInstitutionUsersByProduct
- remove "external-v2" tag from getInstitutions
- remove unused operationIds from external-v2 apim (getInstitutionGeographicTaxonomiesUsingGET, getInstitutionsByGeoTaxonomiesUsingGET)
- used policy with produtId filter for getDelegationsUsingGET

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.