### PR TITLE
[SELC-5605] hotfix: replace userIdForAuth query param with UserId on getInstitutionUsersByProduct

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -475,7 +475,7 @@
             "type" : "string"
           }
         }, {
-          "name" : "userIdForAuth",
+          "name" : "userId",
           "in" : "query",
           "description" : "User's unique identifier",
           "required" : false,

--- a/infra/apim_v2/api/ms_external_api/v2/openapi.dev.json
+++ b/infra/apim_v2/api/ms_external_api/v2/openapi.dev.json
@@ -790,7 +790,7 @@
             }
           },
           {
-            "name": "userIdForAuth",
+            "name": "userId",
             "in": "query",
             "description": "User's unique identifier",
             "required": false,

--- a/infra/apim_v2/api/ms_external_api/v2/openapi.prod.json
+++ b/infra/apim_v2/api/ms_external_api/v2/openapi.prod.json
@@ -790,7 +790,7 @@
             }
           },
           {
-            "name": "userIdForAuth",
+            "name": "userId",
             "in": "query",
             "description": "User's unique identifier",
             "required": false,

--- a/infra/apim_v2/api/ms_external_api/v2/openapi.uat.json
+++ b/infra/apim_v2/api/ms_external_api/v2/openapi.uat.json
@@ -790,7 +790,7 @@
             }
           },
           {
-            "name": "userIdForAuth",
+            "name": "userId",
             "in": "query",
             "description": "User's unique identifier",
             "required": false,

--- a/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/InstitutionV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_api/web/controller/InstitutionV2Controller.java
@@ -122,7 +122,7 @@ public class InstitutionV2Controller {
                                                            @RequestParam(value = "productId", required = false)
                                                            String productId,
                                                            @ApiParam("${swagger.external_api.user.model.id}")
-                                                           @RequestParam(value = "userIdForAuth", required = false)
+                                                           @RequestParam(value = "userId", required = false)
                                                            Optional<String> userId,
                                                            @ApiParam("${swagger.external_api.model.productRoles}")
                                                            @RequestParam(value = "productRoles", required = false)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
userIdForAuth as param causes an restricted list of users with only that user

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.