### PR TITLE
[SELC-5634] feat: added productRoleLabel on response GET /users

### DIFF
--- a/src/main/java/it/pagopa/selfcare/external_api/mapper/UserMapper.java
+++ b/src/main/java/it/pagopa/selfcare/external_api/mapper/UserMapper.java
@@ -3,14 +3,47 @@ package it.pagopa.selfcare.external_api.mapper;
 
 import it.pagopa.selfcare.external_api.model.user.User;
 import it.pagopa.selfcare.external_api.model.user.UserInstitution;
+import it.pagopa.selfcare.onboarding.common.PartyRole;
+import it.pagopa.selfcare.product.entity.Product;
+import it.pagopa.selfcare.product.entity.ProductRole;
+import it.pagopa.selfcare.product.service.ProductService;
+import it.pagopa.selfcare.product.utils.ProductUtils;
+import it.pagopa.selfcare.user.generated.openapi.v1.dto.OnboardedProductResponse;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.UserDetailResponse;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.UserInstitutionResponse;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.springframework.beans.factory.annotation.Autowired;
 
-@Mapper(componentModel = "spring")
-public interface UserMapper {
+import java.util.Optional;
 
-    UserInstitution toUserInstitutionsFromUserInstitutionResponse(UserInstitutionResponse userInstitutionResponse);
+@Mapper(componentModel = "spring", uses = ProductService.class)
+public abstract class UserMapper {
 
-    User toUserFromUserDetailResponse(UserDetailResponse onboardingData);
+    @Autowired
+    ProductService productService;
+
+    public ProductService getProductService(){
+        return this.productService;
+    }
+
+    public abstract UserInstitution toUserInstitutionsFromUserInstitutionResponse(UserInstitutionResponse userInstitutionResponse);
+
+    public abstract User toUserFromUserDetailResponse(UserDetailResponse onboardingData);
+
+    @Mapping(target = "productRoleLabel", expression = "java(toProductRoleLabel(onboardedProduct, getProductService().getProduct(onboardedProduct.getProductId())))")
+    public abstract it.pagopa.selfcare.external_api.model.user.OnboardedProductResponse
+    onboardedProductResponseToOnboardedProductResponse(OnboardedProductResponse onboardedProduct);
+
+    @Named("toProductRoleLabel")
+    protected String toProductRoleLabel(OnboardedProductResponse onboardedProduct, Product product) {
+        ProductRole productRole = null;
+        try { productRole = ProductUtils.getProductRole(onboardedProduct.getProductRole(), PartyRole.valueOf(onboardedProduct.getRole().name()), product); }
+        catch (IllegalArgumentException ignored) {}
+
+        return Optional.ofNullable(productRole)
+                .map(ProductRole::getLabel)
+                .orElse("N.A.");
+    }
 }

--- a/src/main/java/it/pagopa/selfcare/external_api/model/user/OnboardedProductResponse.java
+++ b/src/main/java/it/pagopa/selfcare/external_api/model/user/OnboardedProductResponse.java
@@ -9,6 +9,7 @@ public class OnboardedProductResponse {
   private String productId;
   private String status;
   private String productRole;
+  private String productRoleLabel;
   private String role;
   private LocalDateTime createdAt;
 

--- a/src/main/java/it/pagopa/selfcare/external_api/model/user/UserInstitutionResource.java
+++ b/src/main/java/it/pagopa/selfcare/external_api/model/user/UserInstitutionResource.java
@@ -35,6 +35,8 @@ public class UserInstitutionResource {
         private String status;
         @ApiModelProperty(value = "${swagger.external_api.tokens.model.productRole}")
         private String productRole;
+        @ApiModelProperty(value = "${swagger.external_api.tokens.model.productRoleLabel}")
+        private String productRoleLabel;
         @ApiModelProperty(value = "Available values: MANAGER, DELEGATE, SUB_DELEGATE, OPERATOR, ADMIN_EA")
         private String role;
         private LocalDateTime createdAt;

--- a/src/main/resources/swagger/api-docs.json
+++ b/src/main/resources/swagger/api-docs.json
@@ -2510,6 +2510,10 @@
             "type" : "string",
             "description" : "The specific role of the user related to the product."
           },
+          "productRoleLabel" : {
+            "type" : "string",
+            "description" : "The specific role label of the user related to the product."
+          },
           "role" : {
             "type" : "string",
             "description" : "Available values: MANAGER, DELEGATE, SUB_DELEGATE, OPERATOR, ADMIN_EA"

--- a/src/main/resources/swagger/swagger_en.properties
+++ b/src/main/resources/swagger/swagger_en.properties
@@ -150,6 +150,7 @@ swagger.external_api.api.tokens.findFromProduct=Service to retrieve tokens from 
 swagger.external_api.api.tokens.productId=Product's identifier
 swagger.external_api.api.tokens.status=Token's status. Available values: REQUEST, TOBEVALIDATED, PENDING, COMPLETED, FAILED, REJECTED, DELETED
 swagger.external_api.tokens.model.productRole=The specific role of the user related to the product.
+swagger.external_api.tokens.model.productRoleLabel=The specific role label of the user related to the product.
 swagger.external_api.page.size=Number of elements per page
 swagger.external_api.page.number=Number of page
 swagger.mscore.onboarding.users=The service adds users to the registry if they are not present and associates them with the institution and product contained in the body

--- a/src/test/java/it/pagopa/selfcare/external_api/TestUtils.java
+++ b/src/test/java/it/pagopa/selfcare/external_api/TestUtils.java
@@ -1,0 +1,28 @@
+package it.pagopa.selfcare.external_api;
+
+import it.pagopa.selfcare.product.entity.Product;
+import it.pagopa.selfcare.product.entity.ProductRole;
+import it.pagopa.selfcare.product.entity.ProductRoleInfo;
+
+import java.util.List;
+import java.util.Map;
+
+import static it.pagopa.selfcare.onboarding.common.PartyRole.MANAGER;
+
+public class TestUtils {
+
+    public static Product dummyProduct(String productId) {
+        Product product = new Product();
+        product.setId(productId);
+        ProductRole productRole = new ProductRole();
+        productRole.setCode("admin");
+        productRole.setLabel("Amministratore");
+        productRole.setDescription("Amministratore");
+
+        ProductRoleInfo productRoleInfo = new ProductRoleInfo();
+        productRoleInfo.setRoles(List.of(productRole));
+
+        product.setRoleMappings(Map.of(MANAGER, productRoleInfo));
+        return product;
+    }
+}

--- a/src/test/java/it/pagopa/selfcare/external_api/service/InstitutionServiceImplTest.java
+++ b/src/test/java/it/pagopa/selfcare/external_api/service/InstitutionServiceImplTest.java
@@ -17,6 +17,7 @@ import it.pagopa.selfcare.external_api.model.product.PartyProduct;
 import it.pagopa.selfcare.external_api.model.product.ProductOnboardingStatus;
 import it.pagopa.selfcare.external_api.model.product.ProductResource;
 import it.pagopa.selfcare.external_api.model.user.User;
+import it.pagopa.selfcare.external_api.model.user.UserInstitution;
 import it.pagopa.selfcare.external_api.model.user.UserProductResponse;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.registry_proxy.generated.openapi.v1.dto.LegalVerificationResult;
@@ -41,10 +42,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
 
+import static it.pagopa.selfcare.external_api.TestUtils.dummyProduct;
 import static it.pagopa.selfcare.external_api.model.user.RelationshipState.ACTIVE;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith({SpringExtension.class})
 @ContextConfiguration(classes = {InstitutionServiceImpl.class, UserMapperImpl.class,
@@ -204,6 +207,7 @@ class InstitutionServiceImplTest extends BaseServiceTestUtils {
         });
         Mockito.when(msUserApiRestClient._usersGet(institutionId, null, null, List.of(productId), null, null, List.of(ACTIVE.name()), userId))
                 .thenReturn(ResponseEntity.ok(userInstitutions));
+        when(productService.getProduct(productId)).thenReturn(dummyProduct(productId));
 
         ClassPathResource userResource = new ClassPathResource("expectations/User.json");
         byte[] userStream = Files.readAllBytes(userResource.getFile().toPath());
@@ -238,6 +242,7 @@ class InstitutionServiceImplTest extends BaseServiceTestUtils {
         byte[] userStream = Files.readAllBytes(userResource.getFile().toPath());
         User user = objectMapper.readValue(userStream, User.class);
         when(userRegistryRestClient.getUserByInternalId(any(), any())).thenReturn(user);
+        when(productService.getProduct(productId)).thenReturn(dummyProduct(productId));
 
         Collection<UserProductResponse> result = institutionService.getInstitutionProductUsersV2(institutionId, productId, userId, null, xSelfCareUid);
 
@@ -351,4 +356,5 @@ class InstitutionServiceImplTest extends BaseServiceTestUtils {
         assertNotNull(result);
 
     }
+
 }

--- a/src/test/java/it/pagopa/selfcare/external_api/service/UserServiceImplTest.java
+++ b/src/test/java/it/pagopa/selfcare/external_api/service/UserServiceImplTest.java
@@ -3,20 +3,19 @@ package it.pagopa.selfcare.external_api.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import it.pagopa.selfcare.core.generated.openapi.v1.dto.InstitutionResponse;
 import it.pagopa.selfcare.core.generated.openapi.v1.dto.OnboardedProductResponse;
+import it.pagopa.selfcare.external_api.TestUtils;
 import it.pagopa.selfcare.external_api.client.MsCoreInstitutionApiClient;
 import it.pagopa.selfcare.external_api.client.MsUserApiRestClient;
-import it.pagopa.selfcare.external_api.mapper.InstitutionMapper;
 import it.pagopa.selfcare.external_api.mapper.InstitutionMapperImpl;
-import it.pagopa.selfcare.external_api.mapper.UserMapper;
 import it.pagopa.selfcare.external_api.mapper.UserMapperImpl;
-import it.pagopa.selfcare.external_api.model.institution.Institution;
-import it.pagopa.selfcare.external_api.model.institution.Onboarding;
 import it.pagopa.selfcare.external_api.model.onboarding.Billing;
-import it.pagopa.selfcare.external_api.model.onboarding.OnboardedInstitutionInfo;
 import it.pagopa.selfcare.external_api.model.onboarding.OnboardedInstitutionResource;
-import it.pagopa.selfcare.external_api.model.onboarding.mapper.OnboardingInstitutionMapper;
 import it.pagopa.selfcare.external_api.model.onboarding.mapper.OnboardingInstitutionMapperImpl;
-import it.pagopa.selfcare.external_api.model.user.*;
+import it.pagopa.selfcare.external_api.model.user.UserDetailsWrapper;
+import it.pagopa.selfcare.external_api.model.user.UserInfoWrapper;
+import it.pagopa.selfcare.external_api.model.user.UserInstitution;
+import it.pagopa.selfcare.onboarding.common.PartyRole;
+import it.pagopa.selfcare.product.service.ProductService;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.UserDetailResponse;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.UserInstitutionResponse;
 import org.junit.jupiter.api.Assertions;
@@ -30,16 +29,18 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static it.pagopa.selfcare.external_api.model.user.RelationshipState.ACTIVE;
-import static it.pagopa.selfcare.external_api.model.user.RelationshipState.SUSPENDED;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static reactor.core.publisher.Mono.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceImplTest extends BaseServiceTestUtils {
@@ -60,6 +61,12 @@ class UserServiceImplTest extends BaseServiceTestUtils {
     @Mock
     private MsUserApiRestClient msUserApiRestClient;
 
+    @Mock
+    private ProductService productService;
+
+
+    static final String productId = "product1";
+
 
     @BeforeEach
     public void init() {
@@ -71,7 +78,6 @@ class UserServiceImplTest extends BaseServiceTestUtils {
     void getUserOnboardedProductDetailsV2() throws Exception {
         String userId = "123e4567-e89b-12d3-a456-426614174000";
         String institutionId = "123e4567-e89b-12d3-a456-426614174000";
-        String productId = "product1";
 
         ClassPathResource resource = new ClassPathResource("expectations/UserInstitution.json");
         byte[] resourceStream = Files.readAllBytes(resource.getFile().toPath());
@@ -79,6 +85,8 @@ class UserServiceImplTest extends BaseServiceTestUtils {
         });
         Mockito.when(msUserApiRestClient._usersGet(institutionId, null, null, List.of(productId), null, null, null,userId))
                 .thenReturn(ResponseEntity.ok(userInstitutions));
+        Mockito.when(userMapper.getProductService()).thenReturn(productService);
+        Mockito.when(productService.getProduct(any())).thenReturn(TestUtils.dummyProduct(productId));
 
 
         ClassPathResource expectationResource = new ClassPathResource("expectations/UserDetailsWrapper.json");
@@ -94,7 +102,6 @@ class UserServiceImplTest extends BaseServiceTestUtils {
     void getUserOnboardedProductDetailsV2CheckDateMapping() throws Exception {
         String userId = "123e4567-e89b-12d3-a456-426614174000";
         String institutionId = "123e4567-e89b-12d3-a456-426614174000";
-        String productId = "product1";
 
         ClassPathResource resource = new ClassPathResource("expectations/UserInstitutionWithDate.json");
         byte[] resourceStream = Files.readAllBytes(resource.getFile().toPath());
@@ -102,6 +109,8 @@ class UserServiceImplTest extends BaseServiceTestUtils {
         });
         Mockito.when(msUserApiRestClient._usersGet(institutionId, null, null, List.of(productId), null, null, null,userId))
                 .thenReturn(ResponseEntity.ok(userInstitutions));
+        Mockito.when(userMapper.getProductService()).thenReturn(productService);
+        Mockito.when(productService.getProduct(any())).thenReturn(TestUtils.dummyProduct(productId));
 
         UserDetailsWrapper result = userService.getUserOnboardedProductsDetailsV2(userId, institutionId, productId);
         Assertions.assertNotNull(result.getProductDetails().getCreatedAt());
@@ -111,13 +120,14 @@ class UserServiceImplTest extends BaseServiceTestUtils {
     void getUserOnboardedProductDetailsV2WithoutMatch() throws Exception {
         String userId = "userId";
         String institutionId = "institutionId";
-        String productId = "productId";
         ClassPathResource resource = new ClassPathResource("expectations/UserInstitution.json");
         byte[] resourceStream = Files.readAllBytes(resource.getFile().toPath());
         List<UserInstitutionResponse> userInstitutions = objectMapper.readValue(resourceStream, new TypeReference<>() {
         });
         Mockito.when(msUserApiRestClient._usersGet(institutionId, null, null, List.of(productId), null, null, null,userId))
                 .thenReturn(ResponseEntity.ok(userInstitutions));
+        Mockito.when(userMapper.getProductService()).thenReturn(productService);
+        Mockito.when(productService.getProduct(any())).thenReturn(TestUtils.dummyProduct(productId));
 
         UserDetailsWrapper result = userService.getUserOnboardedProductsDetailsV2(userId, institutionId, productId);
         Assertions.assertNull(result.getProductDetails());
@@ -127,7 +137,6 @@ class UserServiceImplTest extends BaseServiceTestUtils {
     void getOnboardedInstitutionDetailsActiveEmptyList() throws Exception {
         String userId = "123e4567-e89b-12d3-a456-426614174000";
         String institutionId = "123e4567-e89b-12d3-a456-426614174000";
-        String productId = "product1";
         String productIdDeleted = "prod-deleted";
 
         ClassPathResource resource = new ClassPathResource("expectations/UserInstitution.json");
@@ -136,6 +145,9 @@ class UserServiceImplTest extends BaseServiceTestUtils {
         });
         Mockito.when(msUserApiRestClient._usersGet(null, null, null, List.of(productId), null, null, List.of(ACTIVE.name()),userId))
                 .thenReturn(ResponseEntity.ok(userInstitutions));
+        Mockito.when(userMapper.getProductService()).thenReturn(productService);
+        Mockito.when(productService.getProduct(any())).thenReturn(TestUtils.dummyProduct(productId));
+
         InstitutionResponse institution = getInstitutionResponse(productId, productIdDeleted, institutionId);
         institution.getOnboarding().forEach(onboardedProductResponse -> onboardedProductResponse.setStatus(OnboardedProductResponse.StatusEnum.SUSPENDED));
         Mockito.when(institutionApiClient._retrieveInstitutionByIdUsingGET(institutionId)).thenReturn(ResponseEntity.ok(institution));
@@ -150,7 +162,6 @@ class UserServiceImplTest extends BaseServiceTestUtils {
     void getOnboardedInstitutionDetailsActive2() throws Exception {
         String userId = "123e4567-e89b-12d3-a456-426614174000";
         String institutionId = "123e4567-e89b-12d3-a456-426614174000";
-        String productId = "product1";
         String productIdDeleted = "prod-deleted";
         ClassPathResource resource = new ClassPathResource("expectations/UserInstitution.json");
         byte[] resourceStream = Files.readAllBytes(resource.getFile().toPath());
@@ -160,6 +171,8 @@ class UserServiceImplTest extends BaseServiceTestUtils {
                 .thenReturn(ResponseEntity.ok(userInstitutions));
         InstitutionResponse institution = getInstitutionResponse(productId, productIdDeleted, institutionId);
         Mockito.when(institutionApiClient._retrieveInstitutionByIdUsingGET(institutionId)).thenReturn(ResponseEntity.ok(institution));
+        Mockito.when(userMapper.getProductService()).thenReturn(productService);
+        Mockito.when(productService.getProduct(any())).thenReturn(TestUtils.dummyProduct(productId));
 
         List<OnboardedInstitutionResource> result = userService.getOnboardedInstitutionsDetailsActive(userId, productId);
         Assertions.assertNotNull(result);
@@ -171,7 +184,6 @@ class UserServiceImplTest extends BaseServiceTestUtils {
     void getOnboardedInstitutionDetailsActive() throws Exception {
         String userId = "123e4567-e89b-12d3-a456-426614174000";
         String institutionId = "123e4567-e89b-12d3-a456-426614174000";
-        String productId = "product1";
         String productIdDeleted = "prod-deleted";
         ClassPathResource resource = new ClassPathResource("expectations/UserInstitution.json");
         byte[] resourceStream = Files.readAllBytes(resource.getFile().toPath());
@@ -181,6 +193,8 @@ class UserServiceImplTest extends BaseServiceTestUtils {
                 .thenReturn(ResponseEntity.ok(userInstitutions));
         InstitutionResponse institution = getInstitutionResponse(productId, productIdDeleted, institutionId);
         Mockito.when(institutionApiClient._retrieveInstitutionByIdUsingGET(institutionId)).thenReturn(ResponseEntity.ok(institution));
+        Mockito.when(userMapper.getProductService()).thenReturn(productService);
+        Mockito.when(productService.getProduct(any())).thenReturn(TestUtils.dummyProduct(productId));
 
         List<OnboardedInstitutionResource> result = userService.getOnboardedInstitutionsDetailsActive(userId, productId);
         Assertions.assertNotNull(result);
@@ -221,6 +235,8 @@ class UserServiceImplTest extends BaseServiceTestUtils {
 
         Mockito.when(msUserApiRestClient._usersGet(null, null, null, null, null, 350, null,user.getId()))
                 .thenReturn(ResponseEntity.ok(userInstitutions));
+        Mockito.when(userMapper.getProductService()).thenReturn(productService);
+        Mockito.when(productService.getProduct(any())).thenReturn(TestUtils.dummyProduct(productId));
 
         UserInfoWrapper userInfoWrapper = userService.getUserInfoV2(taxCode, List.of(ACTIVE));
 
@@ -246,6 +262,8 @@ class UserServiceImplTest extends BaseServiceTestUtils {
         });
         Mockito.when(msUserApiRestClient._usersGet(null, null, null, null, null, 350, null,user.getId()))
                 .thenReturn(ResponseEntity.ok(userInstitutions));
+        Mockito.when(userMapper.getProductService()).thenReturn(productService);
+        Mockito.when(productService.getProduct(any())).thenReturn(TestUtils.dummyProduct(productId));
 
         InstitutionResponse institution = getInstitutionResponse("product1", "product2", "123e4567-e89b-12d3-a456-426614174000");
         Mockito.when(institutionApiClient._retrieveInstitutionByIdUsingGET("123e4567-e89b-12d3-a456-426614174000")).thenReturn(ResponseEntity.ok(institution));
@@ -262,4 +280,214 @@ class UserServiceImplTest extends BaseServiceTestUtils {
         Assertions.assertEquals(2, userInfoWrapper.getOnboardedInstitutions().size());
         Assertions.assertEquals(objectMapper.writeValueAsString(expectation), objectMapper.writeValueAsString(userInfoWrapper));
     }
+
+    /**
+     * Utility method to create a dummy UserInstitutionResponse.
+     */
+    private UserInstitutionResponse createUserInstitutionResponse(String id, String institutionId) {
+        UserInstitutionResponse response = new UserInstitutionResponse();
+        response.setId(id);
+        response.setInstitutionId(institutionId);
+        // Set other necessary fields as required
+        return response;
+    }
+
+    /**
+     * Test case for successful retrieval of user institutions.
+     * Verifies that the method returns a mapped list of UserInstitution objects when the API returns valid responses.
+     */
+    @Test
+    void testGetUsersInstitutions_Success() {
+        // Input data
+        String userId = "user123";
+        String institutionId = "inst456";
+        Integer page = 1;
+        Integer size = 10;
+        List<String> productRoles = Arrays.asList("role1", "role2");
+        List<String> products = Arrays.asList("prod1", "prod2");
+        List<PartyRole> roles = Arrays.asList(PartyRole.MANAGER, PartyRole.OPERATOR);
+        List<String> states = Arrays.asList("active", "pending");
+
+        // Create dummy UserInstitutionResponse objects
+        UserInstitutionResponse response1 = createUserInstitutionResponse("resp1", institutionId);
+        UserInstitutionResponse response2 = createUserInstitutionResponse("resp2", institutionId);
+        List<UserInstitutionResponse> responseList = Arrays.asList(response1, response2);
+
+        // Mock the API client's _usersGet method to return the dummy responses
+        ResponseEntity<List<UserInstitutionResponse>> mockResponseEntity = ResponseEntity.ok(responseList);
+        when(msUserApiRestClient._usersGet(
+                eq(institutionId),
+                eq(page),
+                eq(productRoles),
+                eq(products),
+                any(), // Adjust if you want to verify specific PartyRole DTOs
+                eq(size),
+                eq(states),
+                eq(userId)
+        )).thenReturn(mockResponseEntity);
+
+        // Execute the method under test
+        List<UserInstitution> result = userService.getUsersInstitutions(userId, institutionId, page, size, productRoles, products, roles, states);
+
+        // Assertions to verify the result
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2);
+
+        // Verify interactions with mocks
+        verify(msUserApiRestClient, times(1))._usersGet(
+                eq(institutionId),
+                eq(page),
+                eq(productRoles),
+                eq(products),
+                any(),
+                eq(size),
+                eq(states),
+                eq(userId)
+        );
+    }
+
+    /**
+     * Test case for handling an empty response from the API.
+     * Verifies that the method returns an empty list when the API returns no UserInstitutionResponse objects.
+     */
+    @Test
+    void testGetUsersInstitutions_EmptyResponse() {
+        // Input data
+        String userId = "user123";
+        String institutionId = "inst456";
+        Integer page = 1;
+        Integer size = 10;
+        List<String> productRoles = Arrays.asList("role1", "role2");
+        List<String> products = Arrays.asList("prod1", "prod2");
+        List<PartyRole> roles = Arrays.asList(PartyRole.MANAGER, PartyRole.OPERATOR);
+        List<String> states = Arrays.asList("active", "pending");
+
+        // Mock the API client's _usersGet method to return an empty list
+        ResponseEntity<List<UserInstitutionResponse>> mockResponseEntity = ResponseEntity.ok(Collections.emptyList());
+        when(msUserApiRestClient._usersGet(
+                eq(institutionId),
+                eq(page),
+                eq(productRoles),
+                eq(products),
+                any(),
+                eq(size),
+                eq(states),
+                eq(userId)
+        )).thenReturn(mockResponseEntity);
+
+        // Execute the method under test
+        List<UserInstitution> result = userService.getUsersInstitutions(userId, institutionId, page, size, productRoles, products, roles, states);
+
+        // Assertions to verify the result
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+
+        // Verify interactions with mocks
+        verify(msUserApiRestClient, times(1))._usersGet(
+                eq(institutionId),
+                eq(page),
+                eq(productRoles),
+                eq(products),
+                any(),
+                eq(size),
+                eq(states),
+                eq(userId)
+        );
+        verify(userMapper, never()).toUserInstitutionsFromUserInstitutionResponse(any());
+    }
+
+    /**
+     * Test case for handling a null response body from the API.
+     * Verifies that the method throws a NullPointerException when the API returns a null body.
+     */
+    @Test
+    void testGetUsersInstitutions_NullResponseBody() {
+        // Input data
+        String userId = "user123";
+        String institutionId = "inst456";
+        Integer page = 1;
+        Integer size = 10;
+        List<String> productRoles = Arrays.asList("role1", "role2");
+        List<String> products = Arrays.asList("prod1", "prod2");
+        List<PartyRole> roles = Arrays.asList(PartyRole.MANAGER, PartyRole.OPERATOR);
+        List<String> states = Arrays.asList("active", "pending");
+
+        // Mock the API client's _usersGet method to return a response with null body
+        ResponseEntity<List<UserInstitutionResponse>> mockResponseEntity = ResponseEntity.ok(null);
+        when(msUserApiRestClient._usersGet(
+                eq(institutionId),
+                eq(page),
+                eq(productRoles),
+                eq(products),
+                any(),
+                eq(size),
+                eq(states),
+                eq(userId)
+        )).thenReturn(mockResponseEntity);
+
+        // Execute the method under test and verify that a NullPointerException is thrown
+        assertThatThrownBy(() -> userService.getUsersInstitutions(userId, institutionId, page, size, productRoles, products, roles, states))
+                .isInstanceOf(NullPointerException.class);
+
+        // Verify interactions with mocks
+        verify(msUserApiRestClient, times(1))._usersGet(
+                eq(institutionId),
+                eq(page),
+                eq(productRoles),
+                eq(products),
+                any(),
+                eq(size),
+                eq(states),
+                eq(userId)
+        );
+        verify(userMapper, never()).toUserInstitutionsFromUserInstitutionResponse(any());
+    }
+
+    /**
+     * Test case for handling exceptions thrown by the API client.
+     * Verifies that the method propagates exceptions thrown by the API client.
+     */
+    @Test
+    void testGetUsersInstitutions_ApiThrowsException() {
+        // Input data
+        String userId = "user123";
+        String institutionId = "inst456";
+        Integer page = 1;
+        Integer size = 10;
+        List<String> productRoles = Arrays.asList("role1", "role2");
+        List<String> products = Arrays.asList("prod1", "prod2");
+        List<PartyRole> roles = Arrays.asList(PartyRole.MANAGER, PartyRole.OPERATOR);
+        List<String> states = Arrays.asList("active", "pending");
+
+        // Mock the API client's _usersGet method to throw a RuntimeException
+        when(msUserApiRestClient._usersGet(
+                eq(institutionId),
+                eq(page),
+                eq(productRoles),
+                eq(products),
+                any(),
+                eq(size),
+                eq(states),
+                eq(userId)
+        )).thenThrow(new RuntimeException("API error"));
+
+        // Execute the method under test and verify that the exception is propagated
+        assertThatThrownBy(() -> userService.getUsersInstitutions(userId, institutionId, page, size, productRoles, products, roles, states))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("API error");
+
+        // Verify interactions with mocks
+        verify(msUserApiRestClient, times(1))._usersGet(
+                eq(institutionId),
+                eq(page),
+                eq(productRoles),
+                eq(products),
+                any(),
+                eq(size),
+                eq(states),
+                eq(userId)
+        );
+        verify(userMapper, never()).toUserInstitutionsFromUserInstitutionResponse(any());
+    }
+
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Updated UserMapper to include the productRoleLabel field, enabling the mapping of user product roles with descriptive labels.
* GET /users include the new productRoleLabel attribute.


#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request introduces the usage of a new configuration option to associate Product Roles based on the InstitutionType explained in this [PR](https://github.com/pagopa/selfcare-onboarding/pull/518)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.