### PR TITLE
[SELC-5775] fix: base_ms_url_external_policy to handle EXTERNAL-OAUTH2-ISSUER

### DIFF
--- a/infra/apim_v2/api/base_ms_url_external_policy.xml.tpl
+++ b/infra/apim_v2/api/base_ms_url_external_policy.xml.tpl
@@ -1,33 +1,34 @@
 <policies>
-  <inbound>
+    <inbound>
+        <choose>
+            <when condition="@(((string)context.Product.Id).Contains(" prod-fd"))">
+            <validate-jwt header-name="Authorization" failed-validation-httpcode="401"
+                          failed-validation-error-message="Unauthorized" require-expiration-time="false"
+                          require-scheme="Bearer" require-signed-tokens="true">
+                <openid-config url="https://login.microsoftonline.com/${TENANT_ID}/.well-known/openid-configuration"/>
+                <required-claims>
+                    <claim name="aud" match="all">
+                        <value>${EXTERNAL-OAUTH2-ISSUER}</value>
+                    </claim>
+                </required-claims>
+            </validate-jwt>
+        </when>
+    </choose>
     <base/>
 
-      <choose>
-      <when condition="@(((string)context.Product.Id).Contains("prod-fd"))">
-        <validate-jwt header-name="Authorization" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized" require-expiration-time="false" require-scheme="Bearer" require-signed-tokens="true">
-          <openid-config url="https://login.microsoftonline.com/${TENANT_ID}/.well-known/openid-configuration" />
-          <required-claims>
-            <claim name="aud" match="all">
-              <value>${EXTERNAL-OAUTH2-ISSUER}</value>
-            </claim>
-          </required-claims>
-        </validate-jwt>
-      </when>
-      </choose>
+    <set-header name="Authorization" exists-action="override">
+        <value>@((string)context.Variables["jwt"])</value>
+    </set-header>
 
-  <set-header name="Authorization" exists-action="override">
-    <value>@((string)context.Variables["jwt"])</value>
-  </set-header>
-
-    <set-backend-service base-url="${MS_BACKEND_URL}" />
-  </inbound>
-  <backend>
-    <base/>
-  </backend>
-  <outbound>
-    <base/>
-  </outbound>
-  <on-error>
-    <base/>
-  </on-error>
-</policies>
+    <set-backend-service base-url="${MS_BACKEND_URL}"/>
+</inbound>
+<backend>
+<base/>
+</backend>
+<outbound>
+<base/>
+</outbound>
+<on-error>
+<base/>
+</on-error>
+        </policies>

--- a/infra/apim_v2/api/base_ms_url_external_product_policy.xml.tpl
+++ b/infra/apim_v2/api/base_ms_url_external_product_policy.xml.tpl
@@ -1,37 +1,38 @@
 <policies>
-  <inbound>
+    <inbound>
+        <choose>
+            <when condition="@(((string)context.Product.Id).Contains(" prod-fd"))">
+            <validate-jwt header-name="Authorization" failed-validation-httpcode="401"
+                          failed-validation-error-message="Unauthorized" require-expiration-time="false"
+                          require-scheme="Bearer" require-signed-tokens="true">
+                <openid-config url="https://login.microsoftonline.com/${TENANT_ID}/.well-known/openid-configuration"/>
+                <required-claims>
+                    <claim name="aud" match="all">
+                        <value>${EXTERNAL-OAUTH2-ISSUER}</value>
+                    </claim>
+                </required-claims>
+            </validate-jwt>
+        </when>
+    </choose>
     <base/>
 
-      <choose>
-      <when condition="@(((string)context.Variables["productId"]).Contains("prod-fd"))">
-        <validate-jwt header-name="Authorization" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized" require-expiration-time="false" require-scheme="Bearer" require-signed-tokens="true">
-          <openid-config url="https://login.microsoftonline.com/${TENANT_ID}/.well-known/openid-configuration" />
-          <required-claims>
-            <claim name="aud" match="all">
-              <value>${EXTERNAL-OAUTH2-ISSUER}</value>
-            </claim>
-          </required-claims>
-        </validate-jwt>
-      </when>
-      </choose>
+    <set-header name="Authorization" exists-action="override">
+        <value>@((string)context.Variables["jwt"])</value>
+    </set-header>
 
-  <set-header name="Authorization" exists-action="override">
-    <value>@((string)context.Variables["jwt"])</value>
-  </set-header>
+    <set-query-parameter name="productId" exists-action="override">
+        <value>@((string)context.Variables["productId"])</value>
+    </set-query-parameter>
 
-  <set-query-parameter name="productId" exists-action="override">
-    <value>@((string)context.Variables["productId"])</value>
-  </set-query-parameter>
-
-    <set-backend-service base-url="${MS_BACKEND_URL}" />
-  </inbound>
-  <backend>
-    <base/>
-  </backend>
-  <outbound>
-    <base/>
-  </outbound>
-  <on-error>
-    <base/>
-  </on-error>
-</policies>
+    <set-backend-service base-url="${MS_BACKEND_URL}"/>
+</inbound>
+<backend>
+<base/>
+</backend>
+<outbound>
+<base/>
+</outbound>
+<on-error>
+<base/>
+</on-error>
+        </policies>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Moving <base />  after <change /> because the creation and setting jwt session spid token should be created after oauth2.0 token validation.
 
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.