### PR TITLE
[SELC-6068] feat: expose getUserGroupById in external-v2

### DIFF
--- a/infra/apim_v2/api/ms_external_api/v2/openapi.prod.json
+++ b/infra/apim_v2/api/ms_external_api/v2/openapi.prod.json
@@ -1481,6 +1481,87 @@
           }
         ]
       }
+    },
+    "/user-groups/{id}": {
+      "get": {
+        "tags": [
+          "UserGroup"
+        ],
+        "summary": "getUserGroup",
+        "description": "Service to get a specific UserGroup entity",
+        "operationId": "getUserGroupUsingGET",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Users group's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserGroupResource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
+      }
     }
   },
   "components": {

--- a/infra/apim_v2/api/ms_external_api/v2/openapi.uat.json
+++ b/infra/apim_v2/api/ms_external_api/v2/openapi.uat.json
@@ -1481,6 +1481,87 @@
           }
         ]
       }
+    },
+    "/user-groups/{id}": {
+      "get": {
+        "tags": [
+          "UserGroup"
+        ],
+        "summary": "getUserGroup",
+        "description": "Service to get a specific UserGroup entity",
+        "operationId": "getUserGroupUsingGET",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Users group's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserGroupResource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
+      }
     }
   },
   "components": {

--- a/infra/apim_v2/apim.tf
+++ b/infra/apim_v2/apim.tf
@@ -321,6 +321,14 @@ module "apim_external_api_ms_v2" {
       })
     },
     {
+      operation_id = "getUserGroupUsingGET"
+      xml_content = templatefile("./api/ms_external_api/v2/base_ms_url_external_policy.xml.tpl", {
+        MS_BACKEND_URL         = "https://selc-${var.env_short}-user-group-ca.${var.ca_suffix_dns_private_name}/v1/"
+        TENANT_ID              = data.azurerm_client_config.current.tenant_id
+        EXTERNAL-OAUTH2-ISSUER = data.azurerm_key_vault_secret.external-oauth2-issuer.value
+      })
+    },
+    {
       operation_id = "V2getUserInfoUsingGET"
       xml_content = templatefile("./api/base_ms_url_external_policy.xml.tpl", {
         MS_BACKEND_URL         = "https://selc-${var.env_short}-ext-api-backend-ca.${var.ca_suffix_dns_private_name}/v2/"

--- a/infra/apim_v2/apim.tf
+++ b/infra/apim_v2/apim.tf
@@ -322,7 +322,7 @@ module "apim_external_api_ms_v2" {
     },
     {
       operation_id = "getUserGroupUsingGET"
-      xml_content = templatefile("./api/ms_external_api/v2/base_ms_url_external_policy.xml.tpl", {
+      xml_content = templatefile("./api/base_ms_url_external_policy.xml.tpl", {
         MS_BACKEND_URL         = "https://selc-${var.env_short}-user-group-ca.${var.ca_suffix_dns_private_name}/v1/"
         TENANT_ID              = data.azurerm_client_config.current.tenant_id
         EXTERNAL-OAUTH2-ISSUER = data.azurerm_key_vault_secret.external-oauth2-issuer.value

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <name>selc-external-api</name>
     <description>Microservice to manage Self Care External API</description>
     <properties>
-        <selc-commons.version>2.5.3</selc-commons.version>
+        <selc-commons.version>2.5.4</selc-commons.version>
         <sonar.host.url>https://sonarcloud.io/</sonar.host.url>
     </properties>
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add getUserGroupById in uat and prod external openapi
- add operationId in apim.tf
- upgrade commons version to 2.5.4

<!--- Describe your changes in detail -->

#### Motivation and Context
This change is required to expose getUserGroupById API in external-v2

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested in dev environment

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.