### PR TITLE
Fix optic exit status

### DIFF
--- a/.github/workflows/call_update_docs_and_notification.yml
+++ b/.github/workflows/call_update_docs_and_notification.yml
@@ -101,6 +101,7 @@ jobs:
         run: |
           set +e
           optic_output=$(optic diff ./docs/${{ inputs.docs_openapi_path }} ${{ env.DIR }}${{ inputs.api_folder_path }}/openapi.${{ inputs.env }}.json)
+          set -e
           echo "$optic_output"
           echo "$optic_output" > optic_diff_output.txt
           if grep -q "Operations: No operations changed" optic_diff_output.txt; then

--- a/.github/workflows/call_update_docs_and_notification.yml
+++ b/.github/workflows/call_update_docs_and_notification.yml
@@ -99,7 +99,8 @@ jobs:
         id: optic_diff
         shell: bash
         run: |
-          optic_output=$(optic diff ./docs/${{ inputs.docs_openapi_path }} ${{ env.DIR }}${{ inputs.api_folder_path }}/openapi.${{ inputs.env }}.json)
+          optic diff ./docs/${{ inputs.docs_openapi_path }} ${{ env.DIR }}${{ inputs.api_folder_path }}/openapi.${{ inputs.env }}.json
+          #optic_output=$(optic diff ./docs/${{ inputs.docs_openapi_path }} ${{ env.DIR }}${{ inputs.api_folder_path }}/openapi.${{ inputs.env }}.json)
           echo "$optic_output"
           echo "$optic_output" > optic_diff_output.txt
           if grep -q "Operations: No operations changed" optic_diff_output.txt; then

--- a/.github/workflows/call_update_docs_and_notification.yml
+++ b/.github/workflows/call_update_docs_and_notification.yml
@@ -99,8 +99,8 @@ jobs:
         id: optic_diff
         shell: bash
         run: |
-          optic diff ./docs/${{ inputs.docs_openapi_path }} ${{ env.DIR }}${{ inputs.api_folder_path }}/openapi.${{ inputs.env }}.json
-          #optic_output=$(optic diff ./docs/${{ inputs.docs_openapi_path }} ${{ env.DIR }}${{ inputs.api_folder_path }}/openapi.${{ inputs.env }}.json)
+          set +e
+          optic_output=$(optic diff ./docs/${{ inputs.docs_openapi_path }} ${{ env.DIR }}${{ inputs.api_folder_path }}/openapi.${{ inputs.env }}.json)
           echo "$optic_output"
           echo "$optic_output" > optic_diff_output.txt
           if grep -q "Operations: No operations changed" optic_diff_output.txt; then


### PR DESCRIPTION
#### List of Changes

- Ignore exit code of optic

#### Motivation and Context

The exit code of optic blocks the workflow

#### How Has This Been Tested?

Github actions tests

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.