### PR TITLE
[SELC-7376] Fixed sendCreateUserNotificationEmail field not working in the onboardingInstitutionUsers API

### DIFF
--- a/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/OnboardingInstitutionUsersRequest.java
+++ b/src/main/java/it/pagopa/selfcare/external_api/model/onboarding/OnboardingInstitutionUsersRequest.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.external_api.model.onboarding;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import it.pagopa.selfcare.external_api.model.user.Person;
 import lombok.Data;
 
@@ -11,18 +12,24 @@ import java.util.Optional;
 @Data
 public class OnboardingInstitutionUsersRequest {
 
+    @Schema(description = "Product to add roles to")
     @NotEmpty(message = "productId is required")
     private String productId;
 
+    @Schema(description = "List of users to add")
     @NotEmpty(message = "at least one user is required")
     private List<Person> users;
 
+    @Schema(description = "The institution ID where users will be added. This takes precedence over the tax code")
     private String institutionId;
 
+    @Schema(description = "Add users to the institution via tax code. Can be used in combination with institutionSubunitCode")
     private String institutionTaxCode;
 
+    @Schema(description = "Add users to the institution via subunit code. Can be used in combination with institutionTaxCode")
     private String institutionSubunitCode;
 
+    @Schema(description = "Send an email notification to the user. By default it's set to true")
     private Boolean sendCreateUserNotificationEmail = Boolean.TRUE;
 
     @AssertTrue(message = "at least one of institutionId or institutionTaxCode must be present")

--- a/src/main/java/it/pagopa/selfcare/external_api/model/user/Person.java
+++ b/src/main/java/it/pagopa/selfcare/external_api/model/user/Person.java
@@ -1,13 +1,13 @@
 package it.pagopa.selfcare.external_api.model.user;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotEmpty;
 
 @Data
 @Valid
@@ -16,15 +16,34 @@ import javax.validation.constraints.NotEmpty;
 @NoArgsConstructor
 public class Person {
 
-    @NotEmpty(message = "User internal id is required")
+    @Schema(description = "User ID of a user already in the registry. A role will be added to the institution/product for the user. It takes precedence over taxCode")
     private String id;
+
+    @Schema(description = "The tax code of the user to add / create. If id is present, the field is ignored")
     private String taxCode;
+
+    @Schema(description = "The name of the user to add / create. If id is present, the field is ignored")
     private String name;
+
+    @Schema(description = "The surname of the user to add / create. If id is present, the field is ignored")
     private String surname;
+
+    @Schema(description = "The email address of the user to add / create. If id is present, the field is ignored")
     private String email;
+
+    @Schema(description = "The email ID of the user already in the registry to be assigned to the institution/product. This field is only used when adding a user by ID")
+    private String userMailUuid;
+
+    @Schema(description = "The role to assign to the user")
     private PartyRole role;
+
+    @Schema(description = "The product role to assign to the user based on the product specifications")
     private String productRole;
+
+    @Schema(description = "Environment. The field is currently not used to create users. It's only returned in response")
     private Env env = Env.ROOT;
+
+    @Schema(description = "The product role label based on the product specifications. The field is currently not used to create users")
     private String roleLabel;
 
     public Person(String id) {

--- a/src/main/java/it/pagopa/selfcare/external_api/model/user/UserToOnboard.java
+++ b/src/main/java/it/pagopa/selfcare/external_api/model/user/UserToOnboard.java
@@ -11,8 +11,10 @@ public class UserToOnboard {
     private String name;
     private String surname;
     private String email;
+    private String userMailUuid;
     private PartyRole role;
     private String productRole;
     private String roleLabel;
     private Env env;
+
 }

--- a/src/main/resources/swagger/api-docs.json
+++ b/src/main/resources/swagger/api-docs.json
@@ -2213,22 +2213,29 @@
         "type" : "object",
         "properties" : {
           "institutionId" : {
-            "type" : "string"
+            "type" : "string",
+            "description" : "The institution ID where users will be added. This takes precedence over the tax code"
           },
           "institutionSubunitCode" : {
-            "type" : "string"
+            "type" : "string",
+            "description" : "Add users to the institution via subunit code. Can be used in combination with institutionTaxCode"
           },
           "institutionTaxCode" : {
-            "type" : "string"
+            "type" : "string",
+            "description" : "Add users to the institution via tax code. Can be used in combination with institutionSubunitCode"
           },
           "productId" : {
-            "type" : "string"
+            "type" : "string",
+            "description" : "Product to add roles to"
           },
           "sendCreateUserNotificationEmail" : {
-            "type" : "boolean"
+            "type" : "boolean",
+            "description" : "Send an email notification to the user. By default it's set to true",
+            "example" : false
           },
           "users" : {
             "type" : "array",
+            "description" : "List of users to add",
             "items" : {
               "$ref" : "#/components/schemas/Person"
             }
@@ -2367,33 +2374,46 @@
         "type" : "object",
         "properties" : {
           "email" : {
-            "type" : "string"
+            "type" : "string",
+            "description" : "The email address of the user to add / create. If id is present, the field is ignored"
           },
           "env" : {
             "type" : "string",
+            "description" : "Environment. The field is currently not used to create users. It's only returned in response",
             "enum" : [ "COLL", "DEV", "PROD", "ROOT" ]
           },
           "id" : {
-            "type" : "string"
+            "type" : "string",
+            "description" : "User ID of a user already in the registry. A role will be added to the institution/product for the user. It takes precedence over taxCode"
           },
           "name" : {
-            "type" : "string"
+            "type" : "string",
+            "description" : "The name of the user to add / create. If id is present, the field is ignored"
           },
           "productRole" : {
-            "type" : "string"
+            "type" : "string",
+            "description" : "The product role to assign to the user based on the product specifications"
           },
           "role" : {
             "type" : "string",
+            "description" : "The role to assign to the user",
             "enum" : [ "ADMIN_EA", "DELEGATE", "MANAGER", "OPERATOR", "SUB_DELEGATE" ]
           },
           "roleLabel" : {
-            "type" : "string"
+            "type" : "string",
+            "description" : "The product role label based on the product specifications. The field is currently not used to create users"
           },
           "surname" : {
-            "type" : "string"
+            "type" : "string",
+            "description" : "The surname of the user to add / create. If id is present, the field is ignored"
           },
           "taxCode" : {
-            "type" : "string"
+            "type" : "string",
+            "description" : "The tax code of the user to add / create. If id is present, the field is ignored"
+          },
+          "userMailUuid" : {
+            "type" : "string",
+            "description" : "The email ID of the user already in the registry to be assigned to the institution/product. This field is only used when adding a user by ID"
           }
         }
       },


### PR DESCRIPTION
#### List of Changes

- Enabled sendCreateUserNotificationEmail parameter
- Added userMailUuid field to use when adding users by id
- Improved API documentation

#### Motivation and Context

The field sendCreateUserNotificationEmail was present in the API, but users were notified anyway.

#### How Has This Been Tested?

- Local tests

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.