### PR TITLE
[SELC-7767] Fix mapping when institutionType is null

### DIFF
--- a/src/main/java/it/pagopa/selfcare/external_api/mapper/InstitutionMapperCustom.java
+++ b/src/main/java/it/pagopa/selfcare/external_api/mapper/InstitutionMapperCustom.java
@@ -7,13 +7,15 @@ import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.Optional;
+
 @NoArgsConstructor(access = AccessLevel.NONE)
 public class InstitutionMapperCustom {
 
     public static InstitutionUpdateResponse toInstitutionUpdateResponse(Institution institution) {
         InstitutionUpdateResponse institutionUpdate = new InstitutionUpdateResponse();
         institutionUpdate.setAddress(institution.getAddress());
-        institutionUpdate.setInstitutionType(InstitutionType.valueOf(institution.getInstitutionType()));
+        institutionUpdate.setInstitutionType(Optional.ofNullable(institution.getInstitutionType()).map(InstitutionType::valueOf).orElse(null));
         institutionUpdate.setDescription(institution.getDescription());
         institutionUpdate.setDigitalAddress(institution.getDigitalAddress());
         institutionUpdate.setTaxCode(institution.getTaxCode());


### PR DESCRIPTION
#### List of Changes

- Considering institutionType nullable in InstitutionUpdateResponse mapping

#### Motivation and Context

The mapper did not consider that institutionType could be null, causing an NPE when invoking Institution.valueOf

#### How Has This Been Tested?

- Local tests
- Unit tests
- Integration tests

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.